### PR TITLE
Significant changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,111 +1,147 @@
 # squeezelite-bluetooth
 
-The following steps describes how to connect a bluetooth-speaker to a ***Raspberry Pi 3B+ and a squeezelight player***.
-The bluetooth-speaker should automaticly connect to the headless raspberry pi and squeezelite should play
-music without touching the raspberry pi.
+Connects a Bluetooth speaker to a **Raspberry Pi running squeezelite**. The speaker auto-connects to the headless Pi; squeezelite starts when the speaker connects and stops when it disconnects — no manual intervention required.
 
-One Problem was, if the BT-speaker disconnects, squeezelite didnt recognize this, create errors and the service stops.
-Another problem was the automaticly reconnection of the BT-speaker. In this solution i created a service to track the connection state of bluetooth-speaker devices and start/stop the squeezelite service.
+A background service tracks the Bluetooth connection state via D-Bus and starts/stops squeezelite accordingly, solving two problems with the naive setup: squeezelite crashing on disconnection, and the speaker not auto-reconnecting.
 
-This guide describe the sound-output for alsa. I have previously tried it unsuccessfully with pulseaudio.
+Audio transport uses **bluez-alsa** (ALSA ↔ Bluetooth bridge). PipeWire is an alternative on modern Raspberry Pi OS — see [PipeWire note](#pipewire-alternative) at the end.
 
-The 2.version of this guide was enhanced with input from 
-* cpd73 forum.slimdevices.com
-* paul- forum.slimdevices.com
-The 3. version of this guide was improved with input from
-* Eric https://github.com/coissac
+*Guide enhanced with input from cpd73 and paul- (forum.slimdevices.com) and Eric (github.com/coissac).*
 
-## Basic installation part
+---
 
-### 1. Check/Install Bluetooth on the raspberry
+## Quick start (recommended)
+
+An installer script handles everything — dependencies, build, files, services, and device pairing:
 
 ```bash
-sudo apt-get install pi-bluetooth
+# Full install (run once from the repo root)
+sudo ./install.sh
+
+# Pair your first Bluetooth speaker
+sudo ./install.sh --add-device
+
+# Check what's running and what's connected
+./install.sh --status
+
+# After changing files, push updates without a full rebuild
+sudo ./install.sh --update
+
+# Remove everything
+sudo ./install.sh --uninstall
 ```
 
-### 2. Check/Install squeezelite on the squeezelite
+The manual steps below explain what the installer does, if you prefer to do it yourself.
+
+---
+
+## How it works
+
+1. When a trusted Bluetooth speaker powers on, it reconnects to the Pi automatically.
+2. The `bluealsa` daemon creates an ALSA audio device for the Bluetooth connection and fires a D-Bus signal (`PCMAdded`).
+3. `btspeaker-monitor.py` receives the signal, looks up the device in `bt-devices`, and spawns a `squeezelite` process pointed at that ALSA device.
+4. squeezelite connects to your LMS server and the player appears — ready to play.
+5. When the speaker powers off, `bluealsa` fires `PCMRemoved`, the monitor stops squeezelite, and the player disappears from LMS.
+
+The monitor also handles failure cases automatically:
+- **Pi boots while speaker is already on:** queries bluealsa for active connections at startup.
+- **bluealsa crashes:** watches for the service restarting and re-queries connections.
+- **squeezelite crashes:** a health check sweep every 10 seconds detects the crash and restarts squeezelite automatically — no speaker power cycle needed.
+
+---
+
+## Manual installation
+
+### 1. Install Bluetooth support
+
+```bash
+sudo apt-get install pi-bluetooth bluez bluez-tools
+```
+
+### 2. Install squeezelite
 
 ```bash
 sudo apt-get install squeezelite
 ```
-Normaly you get here an older version. After installation you can download an replace (/usr/bin/squeezelite) the squeezelite executable from the author of squeezelite
-[Sourceforge squeezelite/Linux](https://sourceforge.net/projects/lmsclients/files/squeezelite/linux/). For raspberry use the arm6f-archives
+
+This installs an older version. For the latest binary, download the appropriate ARM release from [Sourceforge squeezelite/linux](https://sourceforge.net/projects/lmsclients/files/squeezelite/linux/) and replace `/usr/bin/squeezelite`:
+- 32-bit Pi OS (armhf): use the `arm6f` archive
+- 64-bit Pi OS (aarch64): use the `aarch64` archive
 
 ### 3. Build and install bluez-alsa
-This library is used for the transport of sound-data from bluetooth to the alsa sound-system
 
-Install dependencies
+This library bridges Bluetooth audio to the ALSA sound system.
+
+Install build dependencies:
+
 ```bash
 sudo apt-get update
-sudo apt-get install -y libasound2-dev dh-autoreconf libortp-dev \
-          bluez pi-bluetooth bluez-tools libbluetooth-dev \
-          libusb-dev libglib2.0-dev libudev-dev libical-dev \
-          libreadline-dev libsbc1 libsbc-dev \
-          libdbus-glib-1-dev python3-pip
+sudo apt-get install -y \
+  libasound2-dev dh-autoreconf libortp-dev libbluetooth-dev \
+  libusb-dev libglib2.0-dev libudev-dev libical-dev \
+  libreadline-dev libsbc1 libsbc-dev libdbus-glib-1-dev
 ```
 
-Download and build the library
+Build and install. The `--prefix=/usr` flag installs the binary to `/usr/bin/bluealsa`, which matches the service file:
+
 ```bash
 cd ~
 git clone https://github.com/Arkq/bluez-alsa.git
 cd bluez-alsa
 autoreconf --install
 mkdir build && cd build
-../configure --disable-hcitop --with-alsaplugindir=/usr/lib/arm-linux-gnueabihf/alsa-lib
+
+# 32-bit Raspberry Pi OS (armhf):
+../configure --prefix=/usr --disable-hcitop \
+  --with-alsaplugindir=/usr/lib/arm-linux-gnueabihf/alsa-lib
+
+# 64-bit Raspberry Pi OS (aarch64) — use this line instead:
+# ../configure --prefix=/usr --disable-hcitop \
+#   --with-alsaplugindir=/usr/lib/aarch64-linux-gnu/alsa-lib
+
 make && sudo make install
 ```
 
-### 4. Install dbus-python libraries for python3
-This library is used to track the connection-status of a BT-speaker and start/stop the squeezelite service. 
+### 4. Install Python D-Bus and GLib bindings
 
 ```bash
-sudo pip3 install dbus-python
+sudo apt-get install python3-dbus python3-gi
 ```
 
-if the installation of dbus-python fails in case of missing DBUS-1, then you have to install the following library and try again
+### 5. Reboot
 
 ```bash
-sudo apt-get install libdbus-glib-1-dev
+sudo reboot
 ```
 
-### 5. reboot your raspberry
-
-### 6. copy the following files (from /src of this git) to your filesystem
+### 6. Copy files to the filesystem
 
 ```bash
-/etc/pyserver/btspeaker-monitor.py
-/etc/pyserver/bt-devices
-/etc/systemd/system/btspeaker-monitor.service
-/etc/systemd/system/bluezalsa.service
+sudo mkdir -p /etc/pyserver
+sudo cp src/etc/pyserver/btspeaker-monitor.py  /etc/pyserver/
+sudo cp src/etc/pyserver/bt-devices             /etc/pyserver/
+sudo cp src/etc/systemd/system/bluezalsa.service          /etc/systemd/system/
+sudo cp src/etc/systemd/system/btspeaker-monitor.service  /etc/systemd/system/
 ```
 
-### 7. change owner of files to root and create a user lms and add user to group
+### 7. Create the `lms` system user and add to audio group
 
 ```bash
-adduser --disabled-login \
-        --no-create-home \
-        --system  lms
+sudo adduser --disabled-login --no-create-home --system lms
+sudo adduser lms audio
 ```
 
-```bash
-addgroup lms audio
-```
-
+### 8. Set ownership and permissions
 
 ```bash
 sudo chown root:root /etc/pyserver/btspeaker-monitor.py
 sudo chown root:root /etc/pyserver/bt-devices
 sudo chown root:root /etc/systemd/system/btspeaker-monitor.service
 sudo chown root:root /etc/systemd/system/bluezalsa.service
-```
-
-### 8. change execution flag
-
-```bash
 sudo chmod +x /etc/pyserver/btspeaker-monitor.py
 ```
 
-### 9. enable the services
+### 9. Enable and start services
 
 ```bash
 sudo systemctl daemon-reload
@@ -117,58 +153,126 @@ sudo systemctl start btspeaker-monitor.service
 
 ---
 
-## Connect and register your BT-speaker for the first time
+## Pairing your Bluetooth speaker (first time only)
 
-### 1. Turn on your BT-speaker, change to pairing-mode and start the bluetooth-utility
+### 1. Put the speaker in pairing mode, then open bluetoothctl
 
 ```bash
-sudo bluetoothctl 
+sudo bluetoothctl
 ```
 
-```bash
+```
 [bluetooth]# power on
 [bluetooth]# agent on
 [bluetooth]# default-agent
 [bluetooth]# scan on
 ```
 
-After that new recognized devices are listed, you maybe have to wait some time. if your devices is not recognized, then check the pairing mode of your device.
-If your BT-speaker is listed, note the Device-ID as follows 00:00:00:00:00:00
-Then you register your device. please replace all 00:00:00:00:00:00 with your device id
+Wait for your speaker to appear in the list. Note its address (format `AA:BB:CC:DD:EE:FF`). Then:
 
-```bash
+```
 [bluetooth]# scan off
-[bluetooth]# pair 00:00:00:00:00:00
-[bluetooth]# trust 00:00:00:00:00:00
-[bluetooth]# connect 00:00:00:00:00:00
+[bluetooth]# pair AA:BB:CC:DD:EE:FF
+[bluetooth]# trust AA:BB:CC:DD:EE:FF
+[bluetooth]# connect AA:BB:CC:DD:EE:FF
 [bluetooth]# exit
 ```
-if there was no error, your device is now connected, trusted and can connect next time without interaction
 
-### 2. register your BT-speaker and define a nice name
-Edit the following bt-devices and replace 00:00:00:00:00:00 with your device id of the BT-speaker and
-define a nice name after the equal sign. if you have more BT-speaker add more rows
+The device is now trusted and will reconnect automatically on future power-ons.
+
+### 2. Register the speaker in the device list
 
 ```bash
 sudo nano /etc/pyserver/bt-devices
 ```
 
-### 3. reboot your raspberry
+The config uses INI format — one `[MAC]` section per speaker:
+
+```ini
+[AA:BB:CC:DD:EE:FF]
+name = Livingroom
+
+[11:22:33:44:55:66]
+name = Bathroom
+codec = aptx
+lms = 192.168.1.10
+```
+
+| Option | Required | Description |
+|---|---|---|
+| `name` | Yes | Player name in LMS. **No spaces** — use underscores or CamelCase. |
+| `codec` | No | Audio codec: `sbc` (default), `aptx`, `aac`, `sbc-xq`, `faststream`. Only applies if both devices support it. |
+| `lms` | No | LMS server IP or hostname. Omit to auto-discover on LAN via mDNS. |
+
+The file is re-read on every connect event — changes take effect on the next speaker connection without restarting the service.
+
+### 3. Reboot
+
+```bash
+sudo reboot
+```
 
 ---
 
 ## Normal use
 
-### 1. Turn BT-speaker on
+**Turn the speaker on** — squeezelite starts automatically and the player appears in LMS. If it is in a synchronised group, music begins immediately.
 
-The squeezelite can be seen in the LMS-server.
-If the player is in a synchonized group the music starts playing.
-if this didnt happen then turn the BT-speaker off and enable again 
+**Turn the speaker off** — squeezelite stops and the player disappears from LMS. Wait about 30 seconds before turning it back on.
 
-### 2. Turn BT-speaker off
+---
 
-The squeezelite-player disappears in the LMS-server.
-Wait up to one minute to turn the BT-speaker again.
-the squeezelite-service needs some time to stop
+## Troubleshooting
 
+**Check service status:**
+```bash
+sudo systemctl status bluezalsa.service
+sudo systemctl status btspeaker-monitor.service
+```
 
+**Follow live logs:**
+```bash
+sudo journalctl -fu btspeaker-monitor
+sudo journalctl -fu bluezalsa
+```
+
+**Verify the bluealsa ALSA device appears after the speaker connects:**
+```bash
+aplay -L | grep bluealsa
+```
+
+**Check Bluetooth device state:**
+```bash
+bluetoothctl info AA:BB:CC:DD:EE:FF
+```
+
+**Watch D-Bus signals in real time** (useful for confirming the monitor sees events):
+```bash
+dbus-monitor --system "type='signal',interface='org.bluealsa.Manager1'"
+```
+
+**Query what PCMs bluealsa currently knows about:**
+```bash
+busctl call org.bluealsa /org/bluealsa org.bluealsa.Manager1 GetPCMs
+```
+
+**Common problems:**
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Player never appears in LMS | Speaker not trusted / not reconnecting | Re-run `sudo ./install.sh --add-device` |
+| Player appears then immediately disappears | squeezelite can't reach LMS | Set `lms = <ip>` in bt-devices for that speaker |
+| `bluezalsa.service` fails to start | bluealsa binary not at `/usr/bin/bluealsa` | Re-run `sudo ./install.sh` or check `which bluealsa` |
+| `btspeaker-monitor.service` exits instantly | squeezelite or bt-devices not found | Check `/usr/bin/squeezelite` exists and `/etc/pyserver/bt-devices` is present |
+| Sound plays but is choppy | A2DP buffer underrun | Try `export LIBASOUND_THREAD_SAFE=0` before testing manually |
+| Speaker connects but no ALSA device | PipeWire conflict on Bookworm | See PipeWire note below |
+| squeezelite keeps restarting in logs | ALSA or LMS error on startup | Check `journalctl -fu btspeaker-monitor`; set explicit `lms =` in bt-devices |
+| No devices watched after `--update` | bt-devices still in old `MAC=Name` format | Restart the monitor — it auto-migrates the file and backs up the original |
+
+---
+
+## PipeWire alternative
+
+Modern Raspberry Pi OS (Bookworm, 2023+) ships **PipeWire** by default, which handles Bluetooth audio natively without bluez-alsa. If your Pi is already running PipeWire, you can skip building bluez-alsa entirely — configure squeezelite to use `pipewire` as its output and use WirePlumber rules or a BlueZ D-Bus watcher to start/stop it.
+
+The approach in this repo (bluez-alsa + ALSA) works on all Pi OS versions and requires no PipeWire knowledge, making it the more broadly compatible option.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Connects a Bluetooth speaker to a **Raspberry Pi running squeezelite**. The spea
 
 A background service tracks the Bluetooth connection state via D-Bus and starts/stops squeezelite accordingly, solving two problems with the naive setup: squeezelite crashing on disconnection, and the speaker not auto-reconnecting.
 
-Audio transport uses **bluez-alsa** (ALSA ↔ Bluetooth bridge). PipeWire is an alternative on modern Raspberry Pi OS — see [PipeWire note](#pipewire-alternative) at the end.
+The installer auto-detects your audio system and configures accordingly: **bluez-alsa** on older Pi OS (Buster/Bullseye), **PipeWire** on Bookworm (2023+). Both are fully supported.
 
 *Guide enhanced with input from cpd73 and paul- (forum.slimdevices.com) and Eric (github.com/coissac).*
 
@@ -27,8 +27,11 @@ sudo ./install.sh --add-device
 # After changing files, push updates without a full rebuild
 sudo ./install.sh --update
 
-# Remove everything
-sudo ./install.sh --uninstall
+# Remove everything (reads install manifest for precise removal)
+sudo ./uninstall.sh
+
+# Non-interactive removal (e.g. in scripts)
+sudo ./uninstall.sh --yes
 ```
 
 The manual steps below explain what the installer does, if you prefer to do it yourself.
@@ -38,14 +41,17 @@ The manual steps below explain what the installer does, if you prefer to do it y
 ## How it works
 
 1. When a trusted Bluetooth speaker powers on, it reconnects to the Pi automatically.
-2. The `bluealsa` daemon creates an ALSA audio device for the Bluetooth connection and fires a D-Bus signal (`PCMAdded`).
-3. `btspeaker-monitor.py` receives the signal, looks up the device in `bt-devices`, and spawns a `squeezelite` process pointed at that ALSA device.
+2. The audio stack (bluealsa or PipeWire) makes the BT connection available and signals readiness via D-Bus.
+3. `btspeaker-monitor.py` receives the signal, looks up the device in `bt-devices`, and spawns a `squeezelite` process.
 4. squeezelite connects to your LMS server and the player appears — ready to play.
-5. When the speaker powers off, `bluealsa` fires `PCMRemoved`, the monitor stops squeezelite, and the player disappears from LMS.
+5. When the speaker powers off, the monitor detects the disconnection, stops squeezelite, and the player disappears from LMS.
+
+**bluealsa mode** (Buster/Bullseye): watches `PCMAdded`/`PCMRemoved` signals from `org.bluealsa.Manager1`.
+**PipeWire mode** (Bookworm): watches `Connected` property changes directly on BlueZ device objects via `org.freedesktop.DBus.Properties`.
 
 The monitor also handles failure cases automatically:
-- **Pi boots while speaker is already on:** queries bluealsa for active connections at startup.
-- **bluealsa crashes:** watches for the service restarting and re-queries connections.
+- **Pi boots while speaker is already on:** queries the audio stack for active connections at startup.
+- **Audio service crashes:** watches for it restarting and re-queries connections automatically.
 - **squeezelite crashes:** a health check sweep every 10 seconds detects the crash and restarts squeezelite automatically — no speaker power cycle needed.
 
 ---
@@ -68,7 +74,9 @@ This installs an older version. For the latest binary, download the appropriate 
 - 32-bit Pi OS (armhf): use the `arm6f` archive
 - 64-bit Pi OS (aarch64): use the `aarch64` archive
 
-### 3. Build and install bluez-alsa
+### 3. Build and install bluez-alsa *(bluez-alsa backend only)*
+
+Skip this step if your Pi runs Raspberry Pi OS Bookworm — `sudo ./install.sh` detects PipeWire and skips bluez-alsa automatically. Only needed on Buster/Bullseye or if forcing the bluealsa backend.
 
 This library bridges Bluetooth audio to the ALSA sound system.
 
@@ -145,9 +153,10 @@ sudo chmod +x /etc/pyserver/btspeaker-monitor.py
 
 ```bash
 sudo systemctl daemon-reload
+# bluezalsa only needed on bluez-alsa backend (not PipeWire):
 sudo systemctl enable bluezalsa.service
-sudo systemctl enable btspeaker-monitor.service
 sudo systemctl start bluezalsa.service
+sudo systemctl enable btspeaker-monitor.service
 sudo systemctl start btspeaker-monitor.service
 ```
 
@@ -201,7 +210,7 @@ lms = 192.168.1.10
 | Option | Required | Description |
 |---|---|---|
 | `name` | Yes | Player name in LMS. **No spaces** — use underscores or CamelCase. |
-| `codec` | No | Audio codec: `sbc` (default), `aptx`, `aac`, `sbc-xq`, `faststream`. Only applies if both devices support it. |
+| `codec` | No | Audio codec: `sbc` (default), `aptx`, `aac`, `sbc-xq`, `faststream`. bluez-alsa backend only — ignored in PipeWire mode (PipeWire negotiates codec internally). |
 | `lms` | No | LMS server IP or hostname. Omit to auto-discover on LAN via mDNS. |
 
 The file is re-read on every connect event — changes take effect on the next speaker connection without restarting the service.
@@ -236,24 +245,40 @@ sudo journalctl -fu btspeaker-monitor
 sudo journalctl -fu bluezalsa
 ```
 
-**Verify the bluealsa ALSA device appears after the speaker connects:**
-```bash
-aplay -L | grep bluealsa
-```
-
 **Check Bluetooth device state:**
 ```bash
 bluetoothctl info AA:BB:CC:DD:EE:FF
 ```
 
-**Watch D-Bus signals in real time** (useful for confirming the monitor sees events):
+**bluealsa backend — verify ALSA device appears after speaker connects:**
+```bash
+aplay -L | grep bluealsa
+```
+
+**bluealsa backend — watch D-Bus PCM signals in real time:**
 ```bash
 dbus-monitor --system "type='signal',interface='org.bluealsa.Manager1'"
 ```
 
-**Query what PCMs bluealsa currently knows about:**
+**bluealsa backend — query active PCMs:**
 ```bash
 busctl call org.bluealsa /org/bluealsa org.bluealsa.Manager1 GetPCMs
+```
+
+**PipeWire backend — watch BlueZ device property changes in real time:**
+```bash
+dbus-monitor --system "type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged'"
+```
+
+**PipeWire backend — verify WirePlumber is running:**
+```bash
+systemctl status wireplumber
+pgrep -a wireplumber
+```
+
+**Inspect what was installed** (useful after a partial install or upgrade):
+```bash
+cat /var/lib/squeezelite-bluetooth/install.manifest
 ```
 
 **Common problems:**
@@ -265,14 +290,40 @@ busctl call org.bluealsa /org/bluealsa org.bluealsa.Manager1 GetPCMs
 | `bluezalsa.service` fails to start | bluealsa binary not at `/usr/bin/bluealsa` | Re-run `sudo ./install.sh` or check `which bluealsa` |
 | `btspeaker-monitor.service` exits instantly | squeezelite or bt-devices not found | Check `/usr/bin/squeezelite` exists and `/etc/pyserver/bt-devices` is present |
 | Sound plays but is choppy | A2DP buffer underrun | Try `export LIBASOUND_THREAD_SAFE=0` before testing manually |
-| Speaker connects but no ALSA device | PipeWire conflict on Bookworm | See PipeWire note below |
+| Speaker connects but no ALSA device | PipeWire conflict on Bookworm | Re-run `sudo ./install.sh` — it now detects PipeWire and switches backends |
 | squeezelite keeps restarting in logs | ALSA or LMS error on startup | Check `journalctl -fu btspeaker-monitor`; set explicit `lms =` in bt-devices |
 | No devices watched after `--update` | bt-devices still in old `MAC=Name` format | Restart the monitor — it auto-migrates the file and backs up the original |
 
 ---
 
-## PipeWire alternative
+## PipeWire support
 
-Modern Raspberry Pi OS (Bookworm, 2023+) ships **PipeWire** by default, which handles Bluetooth audio natively without bluez-alsa. If your Pi is already running PipeWire, you can skip building bluez-alsa entirely — configure squeezelite to use `pipewire` as its output and use WirePlumber rules or a BlueZ D-Bus watcher to start/stop it.
+Modern Raspberry Pi OS (**Bookworm**, 2023+) ships PipeWire by default. On these systems, bluez-alsa cannot claim the A2DP Bluetooth profile because PipeWire already owns it. The installer detects PipeWire automatically and switches to a PipeWire-native audio path — no manual configuration needed.
 
-The approach in this repo (bluez-alsa + ALSA) works on all Pi OS versions and requires no PipeWire knowledge, making it the more broadly compatible option.
+### What the installer does
+
+```
+sudo ./install.sh          # auto-detects PipeWire or bluez-alsa
+```
+
+| Pi OS version | Detected backend | Audio path |
+|---|---|---|
+| Bookworm (2023+) | PipeWire | squeezelite `-o pipewire` |
+| Bullseye / Buster | bluez-alsa | squeezelite `-o bluealsa:...` |
+
+To override auto-detection:
+```bash
+FORCE_AUDIO_BACKEND=pipewire  sudo ./install.sh   # force PipeWire
+FORCE_AUDIO_BACKEND=bluealsa  sudo ./install.sh   # force bluez-alsa
+```
+
+### How PipeWire mode works
+
+Instead of watching bluez-alsa's `PCMAdded`/`PCMRemoved` D-Bus signals, the monitor watches BlueZ directly for `Connected` property changes on device objects. When a trusted speaker connects, squeezelite is started with `-o pipewire`; PipeWire routes the audio automatically. When the speaker disconnects, squeezelite is stopped.
+
+The `codec` option in `bt-devices` is **not used in PipeWire mode** — PipeWire handles codec negotiation internally.
+
+### Requirements for PipeWire mode
+
+- squeezelite must be compiled with PipeWire support (`-o pipewire`). The `squeezelite` package on Bookworm includes this by default. If you downloaded a binary from Sourceforge, verify it supports PipeWire with `squeezelite -o pipewire -? 2>&1 | head -5`.
+- WirePlumber (PipeWire's session manager) must be running — it handles BT audio routing.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+# install.sh — squeezelite-bluetooth installer for Raspberry Pi
+#
+# Usage:
+#   sudo ./install.sh              # full install
+#   sudo ./install.sh --update     # redeploy files and restart services
+#   sudo ./install.sh --add-device # pair a new Bluetooth speaker
+#        ./install.sh --status     # show current system state (no sudo needed)
+#   sudo ./install.sh --uninstall  # remove everything
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+PYSERVER_DIR=/etc/pyserver
+SERVICE_DIR=/etc/systemd/system
+LMS_USER=lms
+BLUEALSA_SRC="$HOME/bluez-alsa"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Colours
+# ---------------------------------------------------------------------------
+if [[ -t 1 ]]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+  CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; CYAN=''; BOLD=''; NC=''
+fi
+
+step()  { echo -e "\n${CYAN}${BOLD}▶ $*${NC}"; }
+ok()    { echo -e "  ${GREEN}✓${NC} $*"; }
+warn()  { echo -e "  ${YELLOW}⚠${NC}  $*"; }
+err()   { echo -e "  ${RED}✗${NC}  $*" >&2; }
+die()   { err "$*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+check_root() {
+    [[ $EUID -eq 0 ]] || die "Please run as root: sudo $0 ${1:-}"
+}
+
+check_src() {
+    [[ -d "$SCRIPT_DIR/src" ]] || die "Run this script from the repo root (src/ not found)"
+}
+
+# ---------------------------------------------------------------------------
+# Architecture detection
+# ---------------------------------------------------------------------------
+detect_arch() {
+    local machine
+    machine="$(uname -m)"
+    case "$machine" in
+        armv6l|armv7l) ALSA_PLUGIN_DIR=/usr/lib/arm-linux-gnueabihf/alsa-lib ;;
+        aarch64)        ALSA_PLUGIN_DIR=/usr/lib/aarch64-linux-gnu/alsa-lib   ;;
+        *)
+            warn "Unknown architecture '$machine' — defaulting to armhf alsa path"
+            ALSA_PLUGIN_DIR=/usr/lib/arm-linux-gnueabihf/alsa-lib
+            ;;
+    esac
+    ok "Architecture: $machine  →  plugin dir: $ALSA_PLUGIN_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# System dependencies
+# ---------------------------------------------------------------------------
+install_system_deps() {
+    step "Installing system packages"
+    apt-get update -qq
+    apt-get install -y \
+        pi-bluetooth bluez bluez-tools \
+        squeezelite \
+        libasound2-dev dh-autoreconf libortp-dev libbluetooth-dev \
+        libusb-dev libglib2.0-dev libudev-dev libical-dev \
+        libreadline-dev libsbc1 libsbc-dev libdbus-glib-1-dev \
+        python3-dbus python3-gi \
+        git build-essential
+    ok "System packages installed"
+}
+
+# ---------------------------------------------------------------------------
+# bluez-alsa
+# ---------------------------------------------------------------------------
+build_bluealsa_from_source() {
+    step "Building bluez-alsa from source (takes a few minutes)"
+    if [[ -d "$BLUEALSA_SRC/.git" ]]; then
+        ok "Found existing clone at $BLUEALSA_SRC — pulling latest"
+        git -C "$BLUEALSA_SRC" pull --ff-only
+    else
+        git clone https://github.com/Arkq/bluez-alsa.git "$BLUEALSA_SRC"
+    fi
+
+    cd "$BLUEALSA_SRC"
+    autoreconf --install
+
+    local build_dir="$BLUEALSA_SRC/build"
+    mkdir -p "$build_dir"
+    cd "$build_dir"
+
+    ../configure \
+        --prefix=/usr \
+        --disable-hcitop \
+        --with-alsaplugindir="$ALSA_PLUGIN_DIR"
+
+    make -j"$(nproc)"
+    make install
+    ok "bluez-alsa installed to /usr/bin/bluealsa"
+}
+
+install_bluealsa() {
+    step "Checking for bluealsa"
+    if command -v bluealsa &>/dev/null; then
+        ok "bluealsa already installed at $(command -v bluealsa) — skipping build"
+        return 0
+    fi
+
+    # Try apt first (available on Raspberry Pi OS Bookworm+)
+    if apt-cache show bluealsa &>/dev/null 2>&1; then
+        step "Installing bluealsa via apt"
+        apt-get install -y bluealsa
+        ok "bluealsa installed via apt"
+        return 0
+    fi
+
+    build_bluealsa_from_source
+}
+
+# ---------------------------------------------------------------------------
+# Old-format detection
+# ---------------------------------------------------------------------------
+warn_if_old_format() {
+    local cfg="$PYSERVER_DIR/bt-devices"
+    [[ -f "$cfg" ]] || return 0
+    # Old format has bare MAC=Name lines with no [section] headers
+    if grep -qE '^[A-Fa-f0-9]{2}(:[A-Fa-f0-9]{2}){5}=' "$cfg" 2>/dev/null; then
+        warn "bt-devices is in the old MAC=Name format"
+        warn "The monitor will auto-migrate it to INI format on next start"
+        warn "A backup will be saved as ${cfg}.bak"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Deploy files
+# ---------------------------------------------------------------------------
+deploy_files() {
+    step "Deploying files"
+    mkdir -p "$PYSERVER_DIR"
+
+    cp "$SCRIPT_DIR/src/etc/pyserver/btspeaker-monitor.py" "$PYSERVER_DIR/"
+    ok "btspeaker-monitor.py"
+
+    # Never overwrite an existing bt-devices that may contain real entries
+    if [[ ! -f "$PYSERVER_DIR/bt-devices" ]]; then
+        cp "$SCRIPT_DIR/src/etc/pyserver/bt-devices" "$PYSERVER_DIR/"
+        ok "bt-devices (new)"
+    else
+        ok "bt-devices (kept existing)"
+    fi
+
+    cp "$SCRIPT_DIR/src/etc/systemd/system/bluezalsa.service"         "$SERVICE_DIR/"
+    cp "$SCRIPT_DIR/src/etc/systemd/system/btspeaker-monitor.service" "$SERVICE_DIR/"
+    ok "systemd service files"
+}
+
+# ---------------------------------------------------------------------------
+# User & permissions
+# ---------------------------------------------------------------------------
+create_lms_user() {
+    step "Creating lms system user"
+    if id "$LMS_USER" &>/dev/null; then
+        ok "User '$LMS_USER' already exists"
+    else
+        adduser --disabled-login --no-create-home --system "$LMS_USER"
+        ok "User '$LMS_USER' created"
+    fi
+
+    if groups "$LMS_USER" | grep -qw audio; then
+        ok "User '$LMS_USER' already in audio group"
+    else
+        adduser "$LMS_USER" audio
+        ok "Added '$LMS_USER' to audio group"
+    fi
+}
+
+set_permissions() {
+    step "Setting ownership and permissions"
+    chown root:root \
+        "$PYSERVER_DIR/btspeaker-monitor.py" \
+        "$PYSERVER_DIR/bt-devices" \
+        "$SERVICE_DIR/btspeaker-monitor.service" \
+        "$SERVICE_DIR/bluezalsa.service"
+    chmod +x "$PYSERVER_DIR/btspeaker-monitor.py"
+    ok "Permissions set"
+}
+
+# ---------------------------------------------------------------------------
+# Bluetooth auto-power-on
+# ---------------------------------------------------------------------------
+configure_bt_autopoweron() {
+    step "Configuring Bluetooth to auto-power-on after boot"
+    local conf=/etc/bluetooth/main.conf
+    if grep -q 'AutoEnable=true' "$conf" 2>/dev/null; then
+        ok "AutoEnable already set in $conf"
+        return 0
+    fi
+    if grep -q '^\[Policy\]' "$conf" 2>/dev/null; then
+        sed -i '/^\[Policy\]/a AutoEnable=true' "$conf"
+    else
+        printf '\n[Policy]\nAutoEnable=true\n' >> "$conf"
+    fi
+    ok "AutoEnable=true added to $conf"
+}
+
+# ---------------------------------------------------------------------------
+# Services
+# ---------------------------------------------------------------------------
+enable_services() {
+    step "Enabling and starting services"
+    systemctl daemon-reload
+
+    for svc in bluezalsa btspeaker-monitor; do
+        systemctl enable  "${svc}.service"
+        systemctl restart "${svc}.service"
+        ok "${svc}.service enabled and started"
+    done
+}
+
+verify_install() {
+    step "Verifying installation"
+    local all_ok=true
+    for svc in bluezalsa btspeaker-monitor; do
+        if systemctl is-active --quiet "${svc}.service"; then
+            ok "${svc}.service is running"
+        else
+            warn "${svc}.service is NOT running"
+            systemctl status "${svc}.service" --no-pager -l || true
+            all_ok=false
+        fi
+    done
+
+    if $all_ok; then
+        echo
+        echo -e "${GREEN}${BOLD}Installation complete!${NC}"
+        echo
+        echo "  Pair your first Bluetooth speaker:"
+        echo "    sudo $0 --add-device"
+        echo
+        echo "  Check system state at any time:"
+        echo "    $0 --status"
+        echo
+        echo "  Watch live logs:"
+        echo "    sudo journalctl -fu btspeaker-monitor"
+    else
+        echo
+        warn "One or more services failed to start. Check the logs above."
+        echo "  Troubleshoot: sudo journalctl -fu bluezalsa"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Status — show current system state (no root required)
+# ---------------------------------------------------------------------------
+show_status() {
+    echo -e "\n${BOLD}squeezelite-bluetooth status${NC}  ($(date '+%Y-%m-%d %H:%M:%S'))\n"
+
+    # Services
+    echo -e "${BOLD}Services${NC}"
+    for svc in bluezalsa btspeaker-monitor; do
+        local state
+        state="$(systemctl is-active "${svc}.service" 2>/dev/null || echo inactive)"
+        if [[ "$state" == "active" ]]; then
+            local since
+            since="$(systemctl show "${svc}.service" \
+                        --property=ActiveEnterTimestamp --value 2>/dev/null)"
+            echo -e "  ${GREEN}●${NC} ${svc}  (running since ${since})"
+        else
+            echo -e "  ${RED}●${NC} ${svc}  [${state}]"
+        fi
+    done
+    echo
+
+    # Configured devices — parse INI format
+    echo -e "${BOLD}Configured devices${NC}  (${PYSERVER_DIR}/bt-devices)"
+    local cfg="${PYSERVER_DIR}/bt-devices"
+    if [[ -f "$cfg" ]]; then
+        local current_mac="" count=0
+        while IFS= read -r line; do
+            # Strip inline comments and surrounding whitespace
+            line="${line%%#*}"
+            line="${line#"${line%%[![:space:]]*}"}"
+            line="${line%"${line##*[![:space:]]}"}"
+            [[ -z "$line" ]] && continue
+            if [[ "$line" =~ ^\[([A-Fa-f0-9:]+)\]$ ]]; then
+                current_mac="${BASH_REMATCH[1]^^}"
+                count=$((count + 1))
+            elif [[ -n "$current_mac" && "$line" =~ ^name[[:space:]]*=[[:space:]]*(.+)$ ]]; then
+                echo "  ${current_mac}  →  ${BASH_REMATCH[1]}"
+            fi
+        done < "$cfg"
+        [[ $count -eq 0 ]] && echo "  (none — run: sudo $0 --add-device)"
+    else
+        echo "  (file not found — run: sudo ./install.sh)"
+    fi
+    echo
+
+    # Bluetooth device connection state
+    echo -e "${BOLD}Bluetooth devices${NC}  (trusted)"
+    local connected=0
+    while IFS= read -r dev_line; do
+        [[ "$dev_line" =~ ^Device[[:space:]]+([A-Fa-f0-9:]+)[[:space:]]+(.*) ]] || continue
+        local mac="${BASH_REMATCH[1]}"
+        local bt_name="${BASH_REMATCH[2]}"
+        if bluetoothctl info "$mac" 2>/dev/null | grep -q "Connected: yes"; then
+            echo -e "  ${GREEN}✓${NC} $mac  $bt_name"
+            connected=$((connected + 1))
+        else
+            echo    "    $mac  $bt_name  (not connected)"
+        fi
+    done < <(bluetoothctl devices 2>/dev/null)
+    [[ $connected -eq 0 ]] && echo "  (none connected)"
+    echo
+
+    # Running squeezelite processes
+    echo -e "${BOLD}squeezelite processes${NC}"
+    local sq_lines
+    sq_lines="$(pgrep -a squeezelite 2>/dev/null || true)"
+    if [[ -n "$sq_lines" ]]; then
+        while IFS= read -r line; do
+            [[ -n "$line" ]] && echo "  $line"
+        done <<< "$sq_lines"
+    else
+        echo "  (none running)"
+    fi
+    echo
+}
+
+# ---------------------------------------------------------------------------
+# Device pairing wizard
+# ---------------------------------------------------------------------------
+add_device_wizard() {
+    [[ $EUID -eq 0 ]] || die "Please run as root: sudo $0 --add-device"
+
+    echo -e "\n${BOLD}Bluetooth Speaker Pairing Wizard${NC}\n"
+
+    bluetoothctl power on >/dev/null
+
+    echo "Put your speaker into pairing mode, then press Enter to start scanning..."
+    read -r
+
+    step "Scanning for 15 seconds"
+    bluetoothctl scan on &
+    local scan_pid=$!
+    sleep 15
+    kill "$scan_pid" 2>/dev/null || true
+    bluetoothctl scan off >/dev/null 2>&1 || true
+
+    echo
+    echo "Recently discovered devices:"
+    bluetoothctl devices 2>/dev/null | grep -v '^$' || echo "(none — try again, or check speaker pairing mode)"
+    echo
+
+    local mac
+    while true; do
+        read -rp "Enter MAC address (e.g. AA:BB:CC:DD:EE:FF): " mac
+        mac="${mac^^}"
+        [[ "$mac" =~ ^([0-9A-F]{2}:){5}[0-9A-F]{2}$ ]] && break
+        warn "Invalid format — must be 6 hex pairs separated by colons"
+    done
+
+    step "Pairing $mac"
+    bluetoothctl pair    "$mac" || warn "Pair returned an error (device may already be paired)"
+    bluetoothctl trust   "$mac"
+    bluetoothctl connect "$mac" || warn "Connect failed — ensure speaker is in range and powered on"
+
+    local name
+    while true; do
+        read -rp "Player name for LMS (no spaces, e.g. Livingroom): " name
+        name="${name// /_}"
+        [[ -n "$name" ]] && break
+        warn "Name cannot be empty"
+    done
+
+    local lms_addr=""
+    read -rp "LMS server address (leave blank to auto-discover on LAN): " lms_addr
+
+    local config="$PYSERVER_DIR/bt-devices"
+    if grep -q "^\[${mac}\]" "$config" 2>/dev/null; then
+        warn "[$mac] already in bt-devices — updating name"
+        sed -i "/^\[${mac}\]/,/^\[/{s/^name[[:space:]]*=.*/name = ${name}/}" "$config"
+    else
+        {
+            printf '\n[%s]\n' "$mac"
+            printf 'name = %s\n' "$name"
+            [[ -n "$lms_addr" ]] && printf 'lms = %s\n' "$lms_addr"
+        } >> "$config"
+    fi
+    ok "Saved: $name ($mac)"
+
+    step "Restarting btspeaker-monitor"
+    systemctl restart btspeaker-monitor.service
+    ok "Done!  Turn your speaker off and on again to test."
+    echo
+    echo "  Check status: $0 --status"
+    echo "  Watch live:   sudo journalctl -fu btspeaker-monitor"
+}
+
+# ---------------------------------------------------------------------------
+# Update (files only, no build)
+# ---------------------------------------------------------------------------
+do_update() {
+    check_src
+    deploy_files
+    set_permissions
+    warn_if_old_format
+    step "Restarting services"
+    systemctl daemon-reload
+    systemctl restart bluezalsa.service
+    systemctl restart btspeaker-monitor.service
+    ok "Update complete"
+}
+
+# ---------------------------------------------------------------------------
+# Uninstall
+# ---------------------------------------------------------------------------
+do_uninstall() {
+    step "Stopping and disabling services"
+    for svc in btspeaker-monitor bluezalsa; do
+        systemctl stop    "${svc}.service" 2>/dev/null || true
+        systemctl disable "${svc}.service" 2>/dev/null || true
+        rm -f "$SERVICE_DIR/${svc}.service"
+        ok "Removed ${svc}.service"
+    done
+
+    systemctl daemon-reload
+
+    step "Removing files"
+    rm -rf "$PYSERVER_DIR"
+    ok "Removed $PYSERVER_DIR"
+
+    warn "The '$LMS_USER' user and bluealsa binary were NOT removed"
+    warn "To remove manually: userdel $LMS_USER  &&  apt-get remove bluealsa"
+    ok "Uninstall complete"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    check_root
+    check_src
+    detect_arch
+    install_system_deps
+    install_bluealsa
+    deploy_files
+    create_lms_user
+    set_permissions
+    warn_if_old_format
+    configure_bt_autopoweron
+    enable_services
+    verify_install
+}
+
+case "${1:-}" in
+    "")             main ;;
+    --update)       check_root; check_src; do_update ;;
+    --uninstall)    check_root; do_uninstall ;;
+    --add-device)   add_device_wizard ;;
+    --status)       show_status ;;
+    *)
+        echo "Usage: sudo $0 [--update | --uninstall | --add-device | --status]"
+        echo
+        echo "  (no flag)      Full install: dependencies, bluez-alsa, files, services"
+        echo "  --update       Redeploy files and restart services (no rebuild)"
+        echo "  --add-device   Pair a new Bluetooth speaker and register it"
+        echo "  --status       Show service state, configured and connected devices"
+        echo "  --uninstall    Stop services and remove installed files"
+        echo
+        echo "  --status does not require sudo"
+        exit 1
+        ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 #   sudo ./install.sh --update     # redeploy files and restart services
 #   sudo ./install.sh --add-device # pair a new Bluetooth speaker
 #        ./install.sh --status     # show current system state (no sudo needed)
-#   sudo ./install.sh --uninstall  # remove everything
+#   sudo ./install.sh --uninstall  # remove everything (delegates to uninstall.sh)
 
 set -euo pipefail
 
@@ -17,7 +17,15 @@ PYSERVER_DIR=/etc/pyserver
 SERVICE_DIR=/etc/systemd/system
 LMS_USER=lms
 BLUEALSA_SRC="$HOME/bluez-alsa"
+MANIFEST_DIR=/var/lib/squeezelite-bluetooth
+MANIFEST="$MANIFEST_DIR/install.manifest"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Set by detect_audio_backend(); override with FORCE_AUDIO_BACKEND=pipewire|bluealsa
+AUDIO_BACKEND=""
+
+# Guard: manifest_add() only writes during main() to avoid polluting on --update
+WRITING_MANIFEST=false
 
 # ---------------------------------------------------------------------------
 # Colours
@@ -34,6 +42,11 @@ ok()    { echo -e "  ${GREEN}✓${NC} $*"; }
 warn()  { echo -e "  ${YELLOW}⚠${NC}  $*"; }
 err()   { echo -e "  ${RED}✗${NC}  $*" >&2; }
 die()   { err "$*"; exit 1; }
+
+manifest_add() {
+    $WRITING_MANIFEST || return 0
+    echo "$1" >> "$MANIFEST"
+}
 
 # ---------------------------------------------------------------------------
 # Guards
@@ -107,12 +120,20 @@ build_bluealsa_from_source() {
     make -j"$(nproc)"
     make install
     ok "bluez-alsa installed to /usr/bin/bluealsa"
+    manifest_add "BLUEALSA=source:${BLUEALSA_SRC}"
 }
 
 install_bluealsa() {
+    if [[ "$AUDIO_BACKEND" == pipewire ]]; then
+        step "Skipping bluealsa (PipeWire backend in use)"
+        manifest_add "BLUEALSA=skipped-pipewire"
+        return 0
+    fi
+
     step "Checking for bluealsa"
     if command -v bluealsa &>/dev/null; then
         ok "bluealsa already installed at $(command -v bluealsa) — skipping build"
+        manifest_add "BLUEALSA=preexisting"
         return 0
     fi
 
@@ -121,10 +142,57 @@ install_bluealsa() {
         step "Installing bluealsa via apt"
         apt-get install -y bluealsa
         ok "bluealsa installed via apt"
+        manifest_add "BLUEALSA=apt"
         return 0
     fi
 
     build_bluealsa_from_source
+}
+
+# ---------------------------------------------------------------------------
+# Audio backend detection
+# ---------------------------------------------------------------------------
+detect_audio_backend() {
+    step "Detecting audio backend"
+
+    # Allow explicit override via environment variable
+    if [[ -n "${FORCE_AUDIO_BACKEND:-}" ]]; then
+        AUDIO_BACKEND="$FORCE_AUDIO_BACKEND"
+        ok "Audio backend forced to: $AUDIO_BACKEND"
+        manifest_add "AUDIO_BACKEND=$AUDIO_BACKEND"
+        return 0
+    fi
+
+    local is_pw=false
+
+    # WirePlumber running — manages BT audio routing under PipeWire
+    pgrep -x wireplumber &>/dev/null && is_pw=true || true
+
+    # System-level PipeWire service
+    systemctl is-active --quiet pipewire.service 2>/dev/null && is_pw=true || true
+
+    # PipeWire socket for the default Pi user (uid 1000)
+    [[ -S "/run/user/1000/pipewire-0" ]] && is_pw=true || true
+
+    if $is_pw; then
+        AUDIO_BACKEND=pipewire
+        ok "PipeWire detected — using PipeWire audio backend"
+        warn "bluez-alsa will not be installed (not needed with PipeWire)"
+        warn "squeezelite must support -o pipewire; Bookworm's packaged version does"
+        warn "To override: FORCE_AUDIO_BACKEND=bluealsa sudo ./install.sh"
+    else
+        AUDIO_BACKEND=bluealsa
+        ok "PipeWire not detected — using bluez-alsa audio backend"
+        warn "To override: FORCE_AUDIO_BACKEND=pipewire sudo ./install.sh"
+    fi
+
+    manifest_add "AUDIO_BACKEND=$AUDIO_BACKEND"
+}
+
+write_backend_config() {
+    printf 'AUDIO_BACKEND=%s\n' "$AUDIO_BACKEND" > "$PYSERVER_DIR/audio-backend"
+    manifest_add "FILE=$PYSERVER_DIR/audio-backend"
+    ok "Wrote audio-backend config: $AUDIO_BACKEND"
 }
 
 # ---------------------------------------------------------------------------
@@ -133,7 +201,6 @@ install_bluealsa() {
 warn_if_old_format() {
     local cfg="$PYSERVER_DIR/bt-devices"
     [[ -f "$cfg" ]] || return 0
-    # Old format has bare MAC=Name lines with no [section] headers
     if grep -qE '^[A-Fa-f0-9]{2}(:[A-Fa-f0-9]{2}){5}=' "$cfg" 2>/dev/null; then
         warn "bt-devices is in the old MAC=Name format"
         warn "The monitor will auto-migrate it to INI format on next start"
@@ -147,13 +214,16 @@ warn_if_old_format() {
 deploy_files() {
     step "Deploying files"
     mkdir -p "$PYSERVER_DIR"
+    manifest_add "OWNED_DIR=$PYSERVER_DIR"
 
     cp "$SCRIPT_DIR/src/etc/pyserver/btspeaker-monitor.py" "$PYSERVER_DIR/"
+    manifest_add "FILE=$PYSERVER_DIR/btspeaker-monitor.py"
     ok "btspeaker-monitor.py"
 
     # Never overwrite an existing bt-devices that may contain real entries
     if [[ ! -f "$PYSERVER_DIR/bt-devices" ]]; then
         cp "$SCRIPT_DIR/src/etc/pyserver/bt-devices" "$PYSERVER_DIR/"
+        manifest_add "FILE=$PYSERVER_DIR/bt-devices"
         ok "bt-devices (new)"
     else
         ok "bt-devices (kept existing)"
@@ -161,6 +231,8 @@ deploy_files() {
 
     cp "$SCRIPT_DIR/src/etc/systemd/system/bluezalsa.service"         "$SERVICE_DIR/"
     cp "$SCRIPT_DIR/src/etc/systemd/system/btspeaker-monitor.service" "$SERVICE_DIR/"
+    manifest_add "FILE=$SERVICE_DIR/bluezalsa.service"
+    manifest_add "FILE=$SERVICE_DIR/btspeaker-monitor.service"
     ok "systemd service files"
 }
 
@@ -173,6 +245,7 @@ create_lms_user() {
         ok "User '$LMS_USER' already exists"
     else
         adduser --disabled-login --no-create-home --system "$LMS_USER"
+        manifest_add "USER=$LMS_USER"
         ok "User '$LMS_USER' created"
     fi
 
@@ -210,6 +283,7 @@ configure_bt_autopoweron() {
     else
         printf '\n[Policy]\nAutoEnable=true\n' >> "$conf"
     fi
+    manifest_add "BT_AUTOPOWER=$conf"
     ok "AutoEnable=true added to $conf"
 }
 
@@ -220,11 +294,18 @@ enable_services() {
     step "Enabling and starting services"
     systemctl daemon-reload
 
-    for svc in bluezalsa btspeaker-monitor; do
-        systemctl enable  "${svc}.service"
-        systemctl restart "${svc}.service"
-        ok "${svc}.service enabled and started"
-    done
+    # bluezalsa is only needed on the bluez-alsa backend
+    if [[ "$AUDIO_BACKEND" == bluealsa ]]; then
+        systemctl enable  bluezalsa.service
+        systemctl restart bluezalsa.service
+        manifest_add "SERVICE=bluezalsa"
+        ok "bluezalsa.service enabled and started"
+    fi
+
+    systemctl enable  btspeaker-monitor.service
+    systemctl restart btspeaker-monitor.service
+    manifest_add "SERVICE=btspeaker-monitor"
+    ok "btspeaker-monitor.service enabled and started"
 }
 
 verify_install() {
@@ -250,8 +331,8 @@ verify_install() {
         echo "  Check system state at any time:"
         echo "    $0 --status"
         echo
-        echo "  Watch live logs:"
-        echo "    sudo journalctl -fu btspeaker-monitor"
+        echo "  To remove everything later:"
+        echo "    sudo ./uninstall.sh"
     else
         echo
         warn "One or more services failed to start. Check the logs above."
@@ -264,6 +345,18 @@ verify_install() {
 # ---------------------------------------------------------------------------
 show_status() {
     echo -e "\n${BOLD}squeezelite-bluetooth status${NC}  ($(date '+%Y-%m-%d %H:%M:%S'))\n"
+
+    # Install manifest
+    if [[ -f "$MANIFEST" ]]; then
+        local inst_date arch backend
+        inst_date="$(grep '^DATE=' "$MANIFEST" | cut -d= -f2)"
+        arch="$(grep '^ARCH=' "$MANIFEST" | cut -d= -f2)"
+        backend="$(grep '^AUDIO_BACKEND=' "$MANIFEST" | cut -d= -f2)"
+        echo -e "  ${BOLD}Installed:${NC} ${inst_date}  |  arch: ${arch}  |  audio: ${backend:-bluealsa}"
+    else
+        warn "No install manifest found — install may be incomplete"
+    fi
+    echo
 
     # Services
     echo -e "${BOLD}Services${NC}"
@@ -287,7 +380,6 @@ show_status() {
     if [[ -f "$cfg" ]]; then
         local current_mac="" count=0
         while IFS= read -r line; do
-            # Strip inline comments and surrounding whitespace
             line="${line%%#*}"
             line="${line#"${line%%[![:space:]]*}"}"
             line="${line%"${line##*[![:space:]]}"}"
@@ -422,26 +514,24 @@ do_update() {
 }
 
 # ---------------------------------------------------------------------------
-# Uninstall
+# Uninstall — delegate to uninstall.sh
 # ---------------------------------------------------------------------------
 do_uninstall() {
-    step "Stopping and disabling services"
+    local uninstaller="$SCRIPT_DIR/uninstall.sh"
+    if [[ -x "$uninstaller" ]]; then
+        exec "$uninstaller" "${@}"
+    fi
+    # Fallback if uninstall.sh is missing
+    warn "uninstall.sh not found — running basic removal"
     for svc in btspeaker-monitor bluezalsa; do
         systemctl stop    "${svc}.service" 2>/dev/null || true
         systemctl disable "${svc}.service" 2>/dev/null || true
         rm -f "$SERVICE_DIR/${svc}.service"
-        ok "Removed ${svc}.service"
     done
-
     systemctl daemon-reload
-
-    step "Removing files"
     rm -rf "$PYSERVER_DIR"
-    ok "Removed $PYSERVER_DIR"
-
     warn "The '$LMS_USER' user and bluealsa binary were NOT removed"
-    warn "To remove manually: userdel $LMS_USER  &&  apt-get remove bluealsa"
-    ok "Uninstall complete"
+    ok "Basic removal complete"
 }
 
 # ---------------------------------------------------------------------------
@@ -451,21 +541,36 @@ main() {
     check_root
     check_src
     detect_arch
+
+    # Initialise manifest (fresh on every full install)
+    WRITING_MANIFEST=true
+    mkdir -p "$MANIFEST_DIR"
+    {
+        echo "# squeezelite-bluetooth install manifest — do not edit"
+        echo "DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo "ARCH=$(uname -m)"
+        echo "MANIFEST_DIR=$MANIFEST_DIR"
+    } > "$MANIFEST"
+
+    detect_audio_backend
     install_system_deps
     install_bluealsa
     deploy_files
+    write_backend_config
     create_lms_user
     set_permissions
     warn_if_old_format
     configure_bt_autopoweron
     enable_services
     verify_install
+
+    ok "Install manifest written to $MANIFEST"
 }
 
 case "${1:-}" in
     "")             main ;;
     --update)       check_root; check_src; do_update ;;
-    --uninstall)    check_root; do_uninstall ;;
+    --uninstall)    check_root; do_uninstall "${@:2}" ;;
     --add-device)   add_device_wizard ;;
     --status)       show_status ;;
     *)
@@ -475,7 +580,7 @@ case "${1:-}" in
         echo "  --update       Redeploy files and restart services (no rebuild)"
         echo "  --add-device   Pair a new Bluetooth speaker and register it"
         echo "  --status       Show service state, configured and connected devices"
-        echo "  --uninstall    Stop services and remove installed files"
+        echo "  --uninstall    Remove everything (delegates to uninstall.sh)"
         echo
         echo "  --status does not require sudo"
         exit 1

--- a/src/etc/pyserver/bt-devices
+++ b/src/etc/pyserver/bt-devices
@@ -1,2 +1,23 @@
-00:00:00:00:00:00=Livingroom
-AA:BB:CC:DD:EE:FF=Bathroom
+# bt-devices — Bluetooth speaker configuration
+# One [MAC] section per speaker. Add entries with: sudo ./install.sh --add-device
+#
+# Required:
+#   name    Player name shown in LMS — no spaces (use underscores or CamelCase)
+#
+# Optional:
+#   codec   Audio codec: sbc (default), aptx, aac, sbc-xq, faststream
+#           Only applies if both the Pi and speaker support the codec.
+#   lms     LMS server IP or hostname (default: auto-discover via mDNS on LAN)
+#           Set this if auto-discovery fails (e.g. on segmented networks).
+#
+# Changes here take effect on the next speaker connect — no service restart needed.
+#
+# Examples:
+#
+# [AA:BB:CC:DD:EE:FF]
+# name = Livingroom
+#
+# [11:22:33:44:55:66]
+# name = Bathroom
+# codec = aptx
+# lms = 192.168.1.10

--- a/src/etc/pyserver/btspeaker-monitor.py
+++ b/src/etc/pyserver/btspeaker-monitor.py
@@ -1,89 +1,379 @@
 #!/usr/bin/python3 -u
 
-#Version2
-#with contribution from cpd73 / forum.slimdevices.com 
+import configparser
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Optional
 
-from __future__ import absolute_import, print_function, unicode_literals
-
-#from gi.repository import GObject as gobject
-from gi.repository import GLib as glib
-
+from gi.repository import GLib
 import dbus
 import dbus.mainloop.glib
-import os
-from subprocess import Popen
 
-dbg = False
+CONFIG_FILE    = '/etc/pyserver/bt-devices'
+SQUEEZE_LITE   = '/usr/bin/squeezelite'
+BLUEALSA_BUS   = 'org.bluealsa'
+BLUEALSA_PATH  = '/org/bluealsa'
+BLUEALSA_IFACE = 'org.bluealsa.Manager1'
 
-CONFIG_FILE='bt-devices'
-SQUEEZE_LITE='/usr/bin/squeezelite'
-DEVNULL = open(os.devnull, 'w')
+HEALTH_CHECK_INTERVAL_S = 10   # seconds between dead-process sweeps
+STARTUP_QUERY_DELAY_S   = 2    # wait after bluealsa appears before querying PCMs
+RESTART_DELAY_S         = 3    # delay before restarting a crashed squeezelite
 
-players={}
-def debug(*args):
-    if dbg == True:
-        print(*args)
-        
-def connected(hci, dev, name):
-    key=dev.replace(':', '_')
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s: %(message)s',
+    stream=sys.stdout,
+)
+log = logging.getLogger(__name__)
+
+bus = None
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DeviceConfig:
+    mac:   str
+    name:  str
+    codec: Optional[str] = None   # e.g. 'aptx', 'aac', 'sbc-xq'
+    lms:   Optional[str] = None   # LMS server IP/hostname; None = auto-discover
+
+
+@dataclass
+class Player:
+    proc:   subprocess.Popen
+    hci:    str
+    config: DeviceConfig
+
+
+players = {}   # key: 'AA_BB_CC_DD_EE_FF' -> Player
+
+
+# ---------------------------------------------------------------------------
+# Config — INI format, re-read on every connect event for hot-reload
+# ---------------------------------------------------------------------------
+
+def _is_old_format(path):
+    """Return True if the file uses the legacy MAC=Name flat format."""
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    continue
+                if line.startswith('['):
+                    return False   # INI section found — already new format
+                if '=' in line:
+                    key = line.split('=', 1)[0].strip().upper()
+                    if _valid_mac(key):
+                        return True   # MAC=Name line found — old format
+    except OSError:
+        pass
+    return False
+
+
+def _migrate_to_ini(path):
+    """Convert legacy MAC=Name file to INI format in-place; back up the original."""
+    backup = path + '.bak'
+    try:
+        shutil.copy2(path, backup)
+    except OSError as e:
+        log.error("Cannot create backup before migration: %s", e)
+        return
+
+    entries = []
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    continue
+                parts = line.split('=', 1)
+                if len(parts) == 2:
+                    mac  = parts[0].strip().upper()
+                    name = parts[1].strip()
+                    if _valid_mac(mac) and name:
+                        entries.append((mac, name))
+    except OSError as e:
+        log.error("Migration read failed: %s", e)
+        return
+
+    try:
+        with open(path, 'w') as f:
+            f.write("# bt-devices — auto-migrated from old MAC=Name format\n")
+            f.write(f"# Original backed up to: {backup}\n")
+            f.write("#\n")
+            f.write("# name   = Player name in LMS (no spaces)\n")
+            f.write("# codec  = sbc (default) | aptx | aac | sbc-xq | faststream\n")
+            f.write("# lms    = LMS server IP or hostname (default: auto-discover)\n\n")
+            for mac, name in entries:
+                f.write(f"[{mac}]\nname = {name}\n\n")
+        log.warning(
+            "bt-devices migrated from old format — %d device(s) converted. "
+            "Original saved as %s", len(entries), backup,
+        )
+    except OSError as e:
+        log.error("Migration write failed: %s — restoring backup", e)
+        shutil.copy2(backup, path)
+
+
+def load_devices():
+    """Return {uppercase_mac: DeviceConfig} parsed from CONFIG_FILE."""
+    if _is_old_format(CONFIG_FILE):
+        _migrate_to_ini(CONFIG_FILE)
+
+    parser = configparser.ConfigParser()
+    parser.optionxform = str   # preserve key case
+    devices = {}
+    try:
+        if not parser.read(CONFIG_FILE):
+            log.error("Cannot read %s", CONFIG_FILE)
+            return devices
+    except configparser.Error as e:
+        log.error("Error parsing %s: %s", CONFIG_FILE, e)
+        return devices
+
+    for section in parser.sections():
+        mac = section.upper()
+        if not _valid_mac(mac):
+            log.warning("Skipping section [%s]: not a valid MAC address", section)
+            continue
+        name = parser.get(section, 'name', fallback='').strip()
+        if not name:
+            log.warning("Skipping [%s]: missing required 'name' option", mac)
+            continue
+        codec = parser.get(section, 'codec', fallback='').strip() or None
+        lms   = parser.get(section, 'lms',   fallback='').strip() or None
+        devices[mac] = DeviceConfig(mac=mac, name=name, codec=codec, lms=lms)
+
+    return devices
+
+
+def _valid_mac(mac):
+    parts = mac.split(':')
+    if len(parts) != 6:
+        return False
+    try:
+        return all(0 <= int(p, 16) <= 255 for p in parts)
+    except ValueError:
+        return False
+
+
+def get_device_config(dev):
+    return load_devices().get(dev.upper())
+
+
+# ---------------------------------------------------------------------------
+# Player lifecycle
+# ---------------------------------------------------------------------------
+
+def start_squeezelite(hci, device_config, _attempt=0):
+    key = device_config.mac.replace(':', '_')
     if key in players:
+        return False   # already running
+
+    alsa_parts = [f'HCI={hci}', f'DEV={device_config.mac}', 'PROFILE=a2dp-source']
+    if device_config.codec:
+        alsa_parts.append(f'CODEC={device_config.codec}')
+    alsa_dev = 'bluealsa:' + ','.join(alsa_parts)
+
+    cmd = [SQUEEZE_LITE, '-o', alsa_dev, '-n', device_config.name,
+           '-m', device_config.mac, '-f', '/dev/null']
+    if device_config.lms:
+        cmd += ['-s', device_config.lms]
+
+    try:
+        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        players[key] = Player(proc=proc, hci=hci, config=device_config)
+        log.info("Started squeezelite for %s (%s) via %s", device_config.name, device_config.mac, hci)
+    except OSError as e:
+        if _attempt < 3:
+            delay = 2 ** _attempt   # 1 s, 2 s, 4 s
+            log.warning("Failed to start squeezelite for %s — retry in %ds: %s",
+                        device_config.name, delay, e)
+            GLib.timeout_add_seconds(
+                delay,
+                lambda h=hci, c=device_config, a=_attempt: start_squeezelite(h, c, a + 1)
+            )
+        else:
+            log.error("Gave up starting squeezelite for %s after %d attempts: %s",
+                      device_config.name, _attempt, e)
+    return False   # GLib: don't repeat
+
+
+def stop_squeezelite(dev, name):
+    key = dev.replace(':', '_')
+    player = players.pop(key, None)
+    if player is None:
         return
+    log.info("Stopping squeezelite for %s (%s)", name, dev)
+    player.proc.terminate()
+    try:
+        player.proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        log.warning("squeezelite for %s did not stop gracefully, killing", name)
+        player.proc.kill()
+        player.proc.wait()
 
-    debug("Connected %s" % name,hci,dev)
-    debug(SQUEEZE_LITE, '-o', 'bluealsa:HCI=%s,DEV=%s,PROFILE=a2dp' % ( hci,dev), '-n', name, '-m', dev, '-f', '/dev/null')
-    players[key] = Popen([SQUEEZE_LITE, '-o', 'bluealsa:DEV=%s,PROFILE=a2dp' % ( dev), '-n', name, '-m', dev , '-f', '/dev/null'], stdout=DEVNULL, stderr=DEVNULL, shell=False)
 
-def disconnected(dev, name):
-    key=dev.replace(':', '_')
-    if key not in players:
-        return
+def stop_all_players():
+    for player in list(players.values()):
+        stop_squeezelite(player.config.mac, player.config.name)
 
-    debug("Disconnected %s" % name,dev)
-    players[key].kill()
-    os.waitpid(players[key].pid, 0)
-    players.pop(key)
 
-def getName(dev):
-    with open(CONFIG_FILE) as f:
-        for line in f:
-            parts=line.strip().split('=')
-            if 2==len(parts) and dev==parts[0]:
-                return parts[1] 
-    return None
+# ---------------------------------------------------------------------------
+# Health check — sweeps for crashed squeezelite and restarts automatically
+# ---------------------------------------------------------------------------
+
+def check_player_health():
+    for key, player in list(players.items()):
+        if player.proc.poll() is not None:
+            log.warning(
+                "squeezelite for %s exited unexpectedly (code %s) — restarting in %ds",
+                player.config.name, player.proc.returncode, RESTART_DELAY_S,
+            )
+            players.pop(key, None)
+            # Re-read config in case it was edited since last start
+            fresh_config = get_device_config(player.config.mac) or player.config
+            GLib.timeout_add_seconds(
+                RESTART_DELAY_S,
+                lambda h=player.hci, c=fresh_config: start_squeezelite(h, c),
+            )
+    return True   # keep the GLib timeout repeating
+
+
+# ---------------------------------------------------------------------------
+# D-Bus: bluealsa PCM signals
+# ---------------------------------------------------------------------------
+
+def _parse_pcm_path(path):
+    """Return (hci, dev) from /org/bluealsa/hci0/dev_AA_BB_CC_DD_EE_FF/..."""
+    parts = str(path).split('/')
+    if len(parts) < 5:
+        return None, None
+    hci = parts[3]
+    dev = ':'.join(parts[4].split('_')[1:])
+    return hci, dev
+
 
 def bluealsa_handler(path, *args, **kwargs):
-    """Catch all handler.
-    Catch and debug information about all signals.
-    """ 
-    dbus_interface = kwargs['dbus_interface']
-    member = kwargs['member']
-    dev = None
-    hci = None
-    if path:
-        parts=path.split('/')
-        if len(parts)>=4:
-            hci=parts[3]
-            dev=":".join(parts[4].split('_')[1:])
+    member = kwargs.get('member')
+    hci, dev = _parse_pcm_path(path)
+    if not hci or not dev:
+        return
+    device_config = get_device_config(dev)
+    if device_config is None:
+        log.debug("Ignoring unknown device: %s", dev)
+        return
+    if member == 'PCMAdded':
+        start_squeezelite(hci, device_config)
+    elif member == 'PCMRemoved':
+        stop_squeezelite(dev, device_config.name)
 
-    name = None
-    if None!=dev and None!=hci:
-        name = getName(dev)
 
-    if None==name:
-        debug("Unknown device") 
+# ---------------------------------------------------------------------------
+# Startup query — pick up speakers already connected before we started
+# ---------------------------------------------------------------------------
+
+def query_existing_pcms():
+    """Ask bluealsa for its current PCM list; safe to call when not yet up."""
+    try:
+        mgr_obj = bus.get_object(BLUEALSA_BUS, BLUEALSA_PATH)
+        mgr     = dbus.Interface(mgr_obj, BLUEALSA_IFACE)
+        pcms    = mgr.GetPCMs()
+        for path in pcms:
+            bluealsa_handler(path, member='PCMAdded')
+        if pcms:
+            log.info("Picked up %d existing PCM(s) from bluealsa", len(pcms))
+    except dbus.exceptions.DBusException as e:
+        log.debug("Startup PCM query skipped (bluealsa not ready): %s", e)
+    return False   # GLib: don't repeat
+
+
+# ---------------------------------------------------------------------------
+# D-Bus: watch for bluealsa service appearing / disappearing
+# ---------------------------------------------------------------------------
+
+def on_name_owner_changed(name, old_owner, new_owner):
+    if name != BLUEALSA_BUS:
+        return
+    if new_owner:
+        log.info("bluealsa service appeared — querying for active PCMs in %ds",
+                 STARTUP_QUERY_DELAY_S)
+        GLib.timeout_add_seconds(STARTUP_QUERY_DELAY_S, query_existing_pcms)
     else:
-        if member == "PCMRemoved" :
-            disconnected(dev, name)
-        elif member == "PCMAdded" :
-            connected(hci, dev, name)
+        log.warning("bluealsa service disappeared — stopping all players")
+        stop_all_players()
+
+
+# ---------------------------------------------------------------------------
+# Shutdown
+# ---------------------------------------------------------------------------
+
+def shutdown(signum, frame):
+    log.info("Shutting down (signal %d)", signum)
+    stop_all_players()
+    sys.exit(0)
+
+
+# ---------------------------------------------------------------------------
+# Startup validation
+# ---------------------------------------------------------------------------
+
+def preflight_check():
+    ok = True
+    if not os.path.isfile(SQUEEZE_LITE):
+        log.error("squeezelite not found at %s — install it first", SQUEEZE_LITE)
+        ok = False
+    if not os.path.isfile(CONFIG_FILE):
+        log.error("Device config not found at %s — create it first", CONFIG_FILE)
+        ok = False
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 if __name__ == '__main__':
+    if not preflight_check():
+        sys.exit(1)
+
+    signal.signal(signal.SIGTERM, shutdown)
+    signal.signal(signal.SIGINT, shutdown)
+
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
-
     bus = dbus.SystemBus()
-    bus.add_signal_receiver(bluealsa_handler, dbus_interface="org.bluealsa.Manager1", interface_keyword='dbus_interface', member_keyword='member')
 
-    #mainloop = gobject.MainLoop()
-    mainloop = glib.MainLoop()
-    mainloop.run()
-    
+    bus.add_signal_receiver(
+        bluealsa_handler,
+        dbus_interface=BLUEALSA_IFACE,
+        interface_keyword='dbus_interface',
+        member_keyword='member',
+    )
+
+    bus.add_signal_receiver(
+        on_name_owner_changed,
+        dbus_interface='org.freedesktop.DBus',
+        signal_name='NameOwnerChanged',
+        path='/org/freedesktop/DBus',
+    )
+
+    devices = load_devices()
+    if devices:
+        log.info("Watching %d device(s): %s", len(devices),
+                 ', '.join(f"{c.name} ({c.mac})" for c in devices.values()))
+    else:
+        log.warning("No devices in %s — add entries and restart this service", CONFIG_FILE)
+
+    GLib.idle_add(query_existing_pcms)
+    GLib.timeout_add_seconds(HEALTH_CHECK_INTERVAL_S, check_player_health)
+
+    GLib.MainLoop().run()

--- a/src/etc/pyserver/btspeaker-monitor.py
+++ b/src/etc/pyserver/btspeaker-monitor.py
@@ -16,13 +16,22 @@ import dbus.mainloop.glib
 
 CONFIG_FILE    = '/etc/pyserver/bt-devices'
 SQUEEZE_LITE   = '/usr/bin/squeezelite'
+
+# bluez-alsa D-Bus constants
 BLUEALSA_BUS   = 'org.bluealsa'
 BLUEALSA_PATH  = '/org/bluealsa'
 BLUEALSA_IFACE = 'org.bluealsa.Manager1'
 
+# BlueZ D-Bus constants (used in PipeWire mode)
+BLUEZ_BUS          = 'org.bluez'
+BLUEZ_DEVICE_IFACE = 'org.bluez.Device1'
+
 HEALTH_CHECK_INTERVAL_S = 10   # seconds between dead-process sweeps
-STARTUP_QUERY_DELAY_S   = 2    # wait after bluealsa appears before querying PCMs
+STARTUP_QUERY_DELAY_S   = 2    # wait for audio stack to settle after a connect event
 RESTART_DELAY_S         = 3    # delay before restarting a crashed squeezelite
+
+# Written by install.sh to /etc/pyserver/audio-backend; defaults to bluealsa
+AUDIO_BACKEND = os.environ.get('AUDIO_BACKEND', 'bluealsa').lower()
 
 logging.basicConfig(
     level=logging.INFO,
@@ -42,7 +51,7 @@ bus = None
 class DeviceConfig:
     mac:   str
     name:  str
-    codec: Optional[str] = None   # e.g. 'aptx', 'aac', 'sbc-xq'
+    codec: Optional[str] = None   # bluealsa only; ignored in PipeWire mode
     lms:   Optional[str] = None   # LMS server IP/hostname; None = auto-discover
 
 
@@ -69,11 +78,11 @@ def _is_old_format(path):
                 if not line or line.startswith('#'):
                     continue
                 if line.startswith('['):
-                    return False   # INI section found — already new format
+                    return False   # INI section — already new format
                 if '=' in line:
                     key = line.split('=', 1)[0].strip().upper()
                     if _valid_mac(key):
-                        return True   # MAC=Name line found — old format
+                        return True   # bare MAC=Name line — old format
     except OSError:
         pass
     return False
@@ -171,28 +180,36 @@ def get_device_config(dev):
 
 
 # ---------------------------------------------------------------------------
-# Player lifecycle
+# Player lifecycle — shared by both backends
 # ---------------------------------------------------------------------------
+
+def _build_squeezelite_cmd(hci, device_config):
+    """Build the squeezelite command for the active audio backend."""
+    if AUDIO_BACKEND == 'pipewire':
+        # PipeWire handles codec negotiation internally; the codec option is unused.
+        cmd = [SQUEEZE_LITE, '-o', 'pipewire',
+               '-n', device_config.name, '-m', device_config.mac, '-f', '/dev/null']
+    else:
+        alsa_parts = [f'HCI={hci}', f'DEV={device_config.mac}', 'PROFILE=a2dp-source']
+        if device_config.codec:
+            alsa_parts.append(f'CODEC={device_config.codec}')
+        cmd = [SQUEEZE_LITE, '-o', 'bluealsa:' + ','.join(alsa_parts),
+               '-n', device_config.name, '-m', device_config.mac, '-f', '/dev/null']
+    if device_config.lms:
+        cmd += ['-s', device_config.lms]
+    return cmd
+
 
 def start_squeezelite(hci, device_config, _attempt=0):
     key = device_config.mac.replace(':', '_')
     if key in players:
         return False   # already running
 
-    alsa_parts = [f'HCI={hci}', f'DEV={device_config.mac}', 'PROFILE=a2dp-source']
-    if device_config.codec:
-        alsa_parts.append(f'CODEC={device_config.codec}')
-    alsa_dev = 'bluealsa:' + ','.join(alsa_parts)
-
-    cmd = [SQUEEZE_LITE, '-o', alsa_dev, '-n', device_config.name,
-           '-m', device_config.mac, '-f', '/dev/null']
-    if device_config.lms:
-        cmd += ['-s', device_config.lms]
-
+    cmd = _build_squeezelite_cmd(hci, device_config)
     try:
         proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         players[key] = Player(proc=proc, hci=hci, config=device_config)
-        log.info("Started squeezelite for %s (%s) via %s", device_config.name, device_config.mac, hci)
+        log.info("Started squeezelite for %s (%s)", device_config.name, device_config.mac)
     except OSError as e:
         if _attempt < 3:
             delay = 2 ** _attempt   # 1 s, 2 s, 4 s
@@ -229,7 +246,7 @@ def stop_all_players():
 
 
 # ---------------------------------------------------------------------------
-# Health check — sweeps for crashed squeezelite and restarts automatically
+# Health check — shared; auto-restarts crashed squeezelite on either backend
 # ---------------------------------------------------------------------------
 
 def check_player_health():
@@ -240,17 +257,16 @@ def check_player_health():
                 player.config.name, player.proc.returncode, RESTART_DELAY_S,
             )
             players.pop(key, None)
-            # Re-read config in case it was edited since last start
             fresh_config = get_device_config(player.config.mac) or player.config
             GLib.timeout_add_seconds(
                 RESTART_DELAY_S,
                 lambda h=player.hci, c=fresh_config: start_squeezelite(h, c),
             )
-    return True   # keep the GLib timeout repeating
+    return True   # keep repeating
 
 
 # ---------------------------------------------------------------------------
-# D-Bus: bluealsa PCM signals
+# bluez-alsa backend — PCM signal handlers
 # ---------------------------------------------------------------------------
 
 def _parse_pcm_path(path):
@@ -268,22 +284,18 @@ def bluealsa_handler(path, *args, **kwargs):
     hci, dev = _parse_pcm_path(path)
     if not hci or not dev:
         return
-    device_config = get_device_config(dev)
-    if device_config is None:
+    cfg = get_device_config(dev)
+    if cfg is None:
         log.debug("Ignoring unknown device: %s", dev)
         return
     if member == 'PCMAdded':
-        start_squeezelite(hci, device_config)
+        start_squeezelite(hci, cfg)
     elif member == 'PCMRemoved':
-        stop_squeezelite(dev, device_config.name)
+        stop_squeezelite(dev, cfg.name)
 
-
-# ---------------------------------------------------------------------------
-# Startup query — pick up speakers already connected before we started
-# ---------------------------------------------------------------------------
 
 def query_existing_pcms():
-    """Ask bluealsa for its current PCM list; safe to call when not yet up."""
+    """bluez-alsa: pick up speakers already active before we started."""
     try:
         mgr_obj = bus.get_object(BLUEALSA_BUS, BLUEALSA_PATH)
         mgr     = dbus.Interface(mgr_obj, BLUEALSA_IFACE)
@@ -294,23 +306,96 @@ def query_existing_pcms():
             log.info("Picked up %d existing PCM(s) from bluealsa", len(pcms))
     except dbus.exceptions.DBusException as e:
         log.debug("Startup PCM query skipped (bluealsa not ready): %s", e)
-    return False   # GLib: don't repeat
+    return False
 
 
 # ---------------------------------------------------------------------------
-# D-Bus: watch for bluealsa service appearing / disappearing
+# PipeWire backend — BlueZ property change handlers
+# ---------------------------------------------------------------------------
+
+def on_bluez_properties_changed(iface, changed, invalidated, path=None, **kwargs):
+    """PipeWire: fires when any BlueZ object property changes."""
+    if iface != BLUEZ_DEVICE_IFACE:
+        return
+    # Guard against PipeWire's own PropertiesChanged signals on non-BlueZ paths
+    if not str(path).startswith('/org/bluez/'):
+        return
+    if 'Connected' not in changed:
+        return
+
+    connected = bool(changed['Connected'])
+    parts = str(path).split('/')
+    if len(parts) < 5:
+        return
+    hci = parts[3]
+    dev = ':'.join(parts[4].split('_')[1:]).upper()
+
+    cfg = get_device_config(dev)
+    if cfg is None:
+        log.debug("Ignoring unknown device: %s", dev)
+        return
+
+    log.info("BlueZ: %s %s (%s)", cfg.name, "connected" if connected else "disconnected", dev)
+    if connected:
+        # Brief delay: PipeWire needs time to finish A2DP codec negotiation
+        GLib.timeout_add_seconds(
+            STARTUP_QUERY_DELAY_S,
+            lambda h=hci, c=cfg: start_squeezelite(h, c)
+        )
+    else:
+        stop_squeezelite(dev, cfg.name)
+
+
+def query_connected_bluez_devices():
+    """PipeWire: pick up speakers already connected before we started."""
+    try:
+        obj = bus.get_object(BLUEZ_BUS, '/')
+        mgr = dbus.Interface(obj, 'org.freedesktop.DBus.ObjectManager')
+        for path, ifaces in mgr.GetManagedObjects().items():
+            if BLUEZ_DEVICE_IFACE not in ifaces:
+                continue
+            props = ifaces[BLUEZ_DEVICE_IFACE]
+            if not props.get('Connected', False):
+                continue
+            mac = str(props.get('Address', '')).upper()
+            cfg = get_device_config(mac)
+            if cfg is None:
+                continue
+            parts = str(path).split('/')
+            hci = parts[3] if len(parts) >= 4 else 'hci0'
+            log.info("PipeWire startup: found connected device %s (%s)", cfg.name, mac)
+            GLib.timeout_add_seconds(
+                STARTUP_QUERY_DELAY_S,
+                lambda h=hci, c=cfg: start_squeezelite(h, c)
+            )
+    except dbus.exceptions.DBusException as e:
+        log.debug("BlueZ startup query failed: %s", e)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# D-Bus: watch for the relevant audio service appearing / disappearing
 # ---------------------------------------------------------------------------
 
 def on_name_owner_changed(name, old_owner, new_owner):
-    if name != BLUEALSA_BUS:
-        return
-    if new_owner:
-        log.info("bluealsa service appeared — querying for active PCMs in %ds",
-                 STARTUP_QUERY_DELAY_S)
-        GLib.timeout_add_seconds(STARTUP_QUERY_DELAY_S, query_existing_pcms)
+    if AUDIO_BACKEND == 'pipewire':
+        if name != BLUEZ_BUS:
+            return
+        if new_owner:
+            log.info("BlueZ appeared — querying connected devices in %ds", STARTUP_QUERY_DELAY_S)
+            GLib.timeout_add_seconds(STARTUP_QUERY_DELAY_S, query_connected_bluez_devices)
+        else:
+            log.warning("BlueZ disappeared — stopping all players")
+            stop_all_players()
     else:
-        log.warning("bluealsa service disappeared — stopping all players")
-        stop_all_players()
+        if name != BLUEALSA_BUS:
+            return
+        if new_owner:
+            log.info("bluealsa appeared — querying PCMs in %ds", STARTUP_QUERY_DELAY_S)
+            GLib.timeout_add_seconds(STARTUP_QUERY_DELAY_S, query_existing_pcms)
+        else:
+            log.warning("bluealsa disappeared — stopping all players")
+            stop_all_players()
 
 
 # ---------------------------------------------------------------------------
@@ -335,6 +420,10 @@ def preflight_check():
     if not os.path.isfile(CONFIG_FILE):
         log.error("Device config not found at %s — create it first", CONFIG_FILE)
         ok = False
+    if AUDIO_BACKEND == 'pipewire':
+        log.info("Audio backend: PipeWire (ensure squeezelite was built with PipeWire support)")
+    else:
+        log.info("Audio backend: bluez-alsa")
     return ok
 
 
@@ -352,19 +441,30 @@ if __name__ == '__main__':
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
     bus = dbus.SystemBus()
 
-    bus.add_signal_receiver(
-        bluealsa_handler,
-        dbus_interface=BLUEALSA_IFACE,
-        interface_keyword='dbus_interface',
-        member_keyword='member',
-    )
-
+    # Always watch for the relevant audio service restarting
     bus.add_signal_receiver(
         on_name_owner_changed,
         dbus_interface='org.freedesktop.DBus',
         signal_name='NameOwnerChanged',
         path='/org/freedesktop/DBus',
     )
+
+    if AUDIO_BACKEND == 'pipewire':
+        bus.add_signal_receiver(
+            on_bluez_properties_changed,
+            dbus_interface='org.freedesktop.DBus.Properties',
+            signal_name='PropertiesChanged',
+            path_keyword='path',
+        )
+        GLib.idle_add(query_connected_bluez_devices)
+    else:
+        bus.add_signal_receiver(
+            bluealsa_handler,
+            dbus_interface=BLUEALSA_IFACE,
+            interface_keyword='dbus_interface',
+            member_keyword='member',
+        )
+        GLib.idle_add(query_existing_pcms)
 
     devices = load_devices()
     if devices:
@@ -373,7 +473,6 @@ if __name__ == '__main__':
     else:
         log.warning("No devices in %s — add entries and restart this service", CONFIG_FILE)
 
-    GLib.idle_add(query_existing_pcms)
     GLib.timeout_add_seconds(HEALTH_CHECK_INTERVAL_S, check_player_health)
 
     GLib.MainLoop().run()

--- a/src/etc/systemd/system/bluezalsa.service
+++ b/src/etc/systemd/system/bluezalsa.service
@@ -5,7 +5,15 @@ After=bluetooth.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/bluealsa -p a2dp-source
+ExecStart=/usr/bin/bluealsa --profile=a2dp-source
+Restart=on-failure
+RestartSec=5
+
+# Sandboxing — conservative because bluealsa runs as root and needs
+# direct Bluetooth hardware access via AF_BLUETOOTH kernel sockets.
+NoNewPrivileges=yes
+ProtectHome=yes
+PrivateTmp=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/src/etc/systemd/system/btspeaker-monitor.service
+++ b/src/etc/systemd/system/btspeaker-monitor.service
@@ -1,12 +1,16 @@
 [Unit]
 Description=Bluetooth Speaker Connection Monitor
-Requires=bluezalsa.service
+# Wants= (not Requires=) so this service still starts on PipeWire systems
+# where bluezalsa.service is not installed.
+Wants=bluezalsa.service
 After=syslog.target bluetooth.service bluezalsa.service
 
 [Service]
 Type=simple
 User=lms
 Environment=LIBASOUND_THREAD_SAFE=0
+# Audio backend written by install.sh; defaults to bluealsa if file absent.
+EnvironmentFile=-/etc/pyserver/audio-backend
 WorkingDirectory=/etc/pyserver
 ExecStart=/etc/pyserver/btspeaker-monitor.py
 SyslogIdentifier=btspeaker-monitor

--- a/src/etc/systemd/system/btspeaker-monitor.service
+++ b/src/etc/systemd/system/btspeaker-monitor.service
@@ -1,6 +1,7 @@
 [Unit]
-Description=Bluetooth Speaker Connectionmonitor
-After=syslog.target
+Description=Bluetooth Speaker Connection Monitor
+Requires=bluezalsa.service
+After=syslog.target bluetooth.service bluezalsa.service
 
 [Service]
 Type=simple
@@ -9,10 +10,20 @@ Environment=LIBASOUND_THREAD_SAFE=0
 WorkingDirectory=/etc/pyserver
 ExecStart=/etc/pyserver/btspeaker-monitor.py
 SyslogIdentifier=btspeaker-monitor
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=journal
+StandardError=journal
 Restart=always
 RestartSec=3
+
+# Sandboxing — lms user is unprivileged so tighter restrictions are safe.
+# ReadWritePaths allows config migration to write bt-devices in-place.
+# RestrictAddressFamilies is intentionally omitted: the squeezelite
+# subprocess inherits this namespace and needs AF_INET to reach LMS.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/etc/pyserver
+ProtectHome=yes
+PrivateTmp=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# uninstall.sh — squeezelite-bluetooth uninstaller
+#
+# Reads the install manifest written by install.sh to know exactly what was
+# installed, then removes it interactively. Falls back to known default paths
+# if the manifest is missing.
+#
+# Usage:
+#   sudo ./uninstall.sh        # interactive — prompts before sensitive removals
+#   sudo ./uninstall.sh --yes  # non-interactive — auto-confirms all prompts
+
+set -euo pipefail
+
+MANIFEST=/var/lib/squeezelite-bluetooth/install.manifest
+
+# Defaults used when manifest is absent
+DEFAULT_SERVICES=(btspeaker-monitor bluezalsa)
+DEFAULT_FILES=(
+    /etc/systemd/system/bluezalsa.service
+    /etc/systemd/system/btspeaker-monitor.service
+    /etc/pyserver/btspeaker-monitor.py
+)
+DEFAULT_OWNED_DIR=/etc/pyserver
+DEFAULT_USER=lms
+DEFAULT_BT_CONF=/etc/bluetooth/main.conf
+
+# ---------------------------------------------------------------------------
+# Args
+# ---------------------------------------------------------------------------
+YES=false
+for arg in "${@}"; do
+    case "$arg" in
+        --yes) YES=true ;;
+        --help|-h)
+            echo "Usage: sudo $0 [--yes]"
+            echo
+            echo "  --yes   Non-interactive: answer yes to all prompts"
+            exit 0
+            ;;
+        *) echo "Unknown option: $arg"; exit 1 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Colours
+# ---------------------------------------------------------------------------
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+    CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; CYAN=''; BOLD=''; NC=''
+fi
+
+step() { echo -e "\n${CYAN}${BOLD}▶ $*${NC}"; }
+ok()   { echo -e "  ${GREEN}✓${NC} $*"; }
+warn() { echo -e "  ${YELLOW}⚠${NC}  $*"; }
+info() { echo    "    $*"; }
+die()  { echo -e "  ${RED}✗${NC}  $*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || die "Please run as root: sudo $0"
+
+# ---------------------------------------------------------------------------
+# Read manifest into typed arrays
+# ---------------------------------------------------------------------------
+declare -a M_SERVICES=()
+declare -a M_FILES=()
+declare -a M_OWNED_DIRS=()
+declare -a M_USERS=()
+declare -a M_BT_CONFS=()
+M_BLUEALSA_METHOD=""
+M_BLUEALSA_SRC=""
+M_MANIFEST_DIR=""
+M_DATE="unknown"
+M_ARCH="unknown"
+
+if [[ -f "$MANIFEST" ]]; then
+    echo -e "${BOLD}Install manifest:${NC} $MANIFEST"
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line// /}" ]]          && continue
+        [[ "$line" =~ ^([^=]+)=(.*)$ ]] || continue
+        key="${BASH_REMATCH[1]}"
+        val="${BASH_REMATCH[2]}"
+        case "$key" in
+            DATE)         M_DATE="$val" ;;
+            ARCH)         M_ARCH="$val" ;;
+            SERVICE)      M_SERVICES+=("$val") ;;
+            FILE)         M_FILES+=("$val") ;;
+            OWNED_DIR)    M_OWNED_DIRS+=("$val") ;;
+            USER)         M_USERS+=("$val") ;;
+            BT_AUTOPOWER) M_BT_CONFS+=("$val") ;;
+            BLUEALSA)
+                case "$val" in
+                    apt)        M_BLUEALSA_METHOD=apt ;;
+                    source:*)   M_BLUEALSA_METHOD=source; M_BLUEALSA_SRC="${val#source:}" ;;
+                    preexisting) M_BLUEALSA_METHOD=preexisting ;;
+                esac ;;
+            MANIFEST_DIR) M_MANIFEST_DIR="$val" ;;
+        esac
+    done < "$MANIFEST"
+    echo -e "  Installed: ${M_DATE}  |  arch: ${M_ARCH}\n"
+else
+    warn "No manifest at $MANIFEST — using default known paths"
+    echo
+    M_SERVICES=("${DEFAULT_SERVICES[@]}")
+    M_FILES=("${DEFAULT_FILES[@]}")
+    M_OWNED_DIRS=("$DEFAULT_OWNED_DIR")
+    M_USERS=("$DEFAULT_USER")
+    M_BT_CONFS=("$DEFAULT_BT_CONF")
+fi
+
+# ---------------------------------------------------------------------------
+# Preview everything that will be removed
+# ---------------------------------------------------------------------------
+echo -e "${BOLD}The following will be removed:${NC}\n"
+
+if [[ ${#M_SERVICES[@]} -gt 0 ]]; then
+    echo -e "  ${BOLD}Services${NC} (stop + disable)"
+    for s in "${M_SERVICES[@]}"; do printf "    %s.service\n" "$s"; done
+    echo
+fi
+
+if [[ ${#M_FILES[@]} -gt 0 ]]; then
+    echo -e "  ${BOLD}Files${NC}"
+    for f in "${M_FILES[@]}"; do
+        [[ -f "$f" ]] \
+            && printf "    %s\n" "$f" \
+            || printf "    %s  ${YELLOW}(not found)${NC}\n" "$f"
+    done
+    echo
+fi
+
+if [[ ${#M_OWNED_DIRS[@]} -gt 0 ]]; then
+    echo -e "  ${BOLD}Directories${NC} (contents shown before removal)"
+    for d in "${M_OWNED_DIRS[@]}"; do
+        [[ -d "$d" ]] \
+            && printf "    %s/\n" "$d" \
+            || printf "    %s/  ${YELLOW}(not found)${NC}\n" "$d"
+    done
+    echo
+fi
+
+if [[ ${#M_BT_CONFS[@]} -gt 0 ]]; then
+    echo -e "  ${BOLD}Config reverts${NC}"
+    for f in "${M_BT_CONFS[@]}"; do
+        printf "    Remove AutoEnable=true from %s\n" "$f"
+    done
+    echo
+fi
+
+if [[ -n "$M_BLUEALSA_METHOD" && "$M_BLUEALSA_METHOD" != preexisting ]]; then
+    echo -e "  ${BOLD}bluealsa${NC} — optional, will prompt  (installed via ${M_BLUEALSA_METHOD})"
+    echo
+fi
+
+if [[ ${#M_USERS[@]} -gt 0 ]]; then
+    echo -e "  ${BOLD}System users${NC} — optional, will prompt"
+    for u in "${M_USERS[@]}"; do printf "    %s\n" "$u"; done
+    echo
+fi
+
+# ---------------------------------------------------------------------------
+# Confirmation helper
+# ---------------------------------------------------------------------------
+confirm() {
+    local prompt="$1"
+    if $YES; then
+        echo -e "  ${YELLOW}⚠${NC}  ${prompt} [auto-confirmed --yes]"
+        return 0
+    fi
+    read -rp "  ${prompt} [y/N] " ans
+    [[ "${ans,,}" == "y" ]]
+}
+
+confirm "Proceed with uninstall?" || { echo "Aborted."; exit 0; }
+
+# ---------------------------------------------------------------------------
+# Step 1: Stop and disable services
+# ---------------------------------------------------------------------------
+if [[ ${#M_SERVICES[@]} -gt 0 ]]; then
+    step "Stopping and disabling services"
+    for svc in "${M_SERVICES[@]}"; do
+        if systemctl is-active --quiet "${svc}.service" 2>/dev/null; then
+            systemctl stop "${svc}.service"
+            ok "Stopped ${svc}.service"
+        else
+            info "${svc}.service was not running"
+        fi
+        if systemctl is-enabled --quiet "${svc}.service" 2>/dev/null; then
+            systemctl disable "${svc}.service"
+            ok "Disabled ${svc}.service"
+        fi
+    done
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: Remove tracked files
+# ---------------------------------------------------------------------------
+if [[ ${#M_FILES[@]} -gt 0 ]]; then
+    step "Removing files"
+    removed_count=0
+    for f in "${M_FILES[@]}"; do
+        if [[ -f "$f" ]]; then
+            rm -f "$f"
+            ok "Removed $f"
+            removed_count=$((removed_count + 1))
+        else
+            info "Already gone: $f"
+        fi
+    done
+    if [[ $removed_count -gt 0 ]]; then
+        systemctl daemon-reload
+        ok "systemctl daemon-reload"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: Handle owned directories
+# ---------------------------------------------------------------------------
+for d in "${M_OWNED_DIRS[@]}"; do
+    [[ -d "$d" ]] || continue
+    step "Directory: $d"
+
+    # Collect remaining contents
+    mapfile -d '' remaining < <(find "$d" -maxdepth 1 -mindepth 1 -print0 2>/dev/null)
+
+    if [[ ${#remaining[@]} -eq 0 ]]; then
+        rmdir "$d"
+        ok "Removed empty directory $d"
+        continue
+    fi
+
+    echo "  Contents:"
+    for item in "${remaining[@]}"; do
+        printf "    %s\n" "$item"
+    done
+
+    # Warn if bt-devices has real device entries
+    btdev_path="$d/bt-devices"
+    if [[ -f "$btdev_path" ]] && grep -qE '^\[[A-Fa-f0-9:]+\]' "$btdev_path" 2>/dev/null; then
+        warn "bt-devices contains configured speaker entries"
+    fi
+    echo
+
+    if confirm "Remove $d and all its contents?"; then
+        rm -rf "$d"
+        ok "Removed $d"
+    else
+        warn "Kept $d"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Step 4: Revert Bluetooth auto-power-on
+# ---------------------------------------------------------------------------
+for conf in "${M_BT_CONFS[@]}"; do
+    if [[ -f "$conf" ]] && grep -q 'AutoEnable=true' "$conf" 2>/dev/null; then
+        step "Reverting Bluetooth auto-power setting"
+        sed -i '/^AutoEnable=true$/d' "$conf"
+        ok "Removed AutoEnable=true from $conf"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Step 5: Optionally remove lms user
+# ---------------------------------------------------------------------------
+for user in "${M_USERS[@]}"; do
+    if id "$user" &>/dev/null; then
+        step "System user '$user'"
+        if confirm "Remove system user '$user'?"; then
+            userdel "$user" 2>/dev/null \
+                || userdel --force "$user" 2>/dev/null \
+                || warn "userdel failed — remove manually: userdel $user"
+            ok "Removed user '$user'"
+        else
+            warn "Kept user '$user'"
+        fi
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Step 6: Optionally remove bluealsa
+# ---------------------------------------------------------------------------
+if [[ -n "$M_BLUEALSA_METHOD" && "$M_BLUEALSA_METHOD" != preexisting ]]; then
+    if command -v bluealsa &>/dev/null; then
+        step "bluealsa (installed via $M_BLUEALSA_METHOD)"
+        if confirm "Remove bluealsa?"; then
+            case "$M_BLUEALSA_METHOD" in
+                apt)
+                    apt-get remove -y bluealsa 2>/dev/null \
+                        && ok "Removed bluealsa via apt" \
+                        || warn "apt remove failed — try: apt-get remove bluealsa"
+                    ;;
+                source)
+                    if [[ -n "$M_BLUEALSA_SRC" && -f "$M_BLUEALSA_SRC/build/Makefile" ]]; then
+                        make -C "$M_BLUEALSA_SRC/build" uninstall 2>/dev/null \
+                            && ok "Removed bluealsa (make uninstall)" \
+                            || { rm -f /usr/bin/bluealsa; ok "Removed /usr/bin/bluealsa"; }
+                    else
+                        rm -f /usr/bin/bluealsa
+                        ok "Removed /usr/bin/bluealsa"
+                    fi
+                    ;;
+            esac
+        else
+            warn "Kept bluealsa"
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 7: Remove manifest
+# ---------------------------------------------------------------------------
+if [[ -f "$MANIFEST" ]]; then
+    rm -f "$MANIFEST"
+    ok "Removed install manifest"
+fi
+if [[ -n "$M_MANIFEST_DIR" && -d "$M_MANIFEST_DIR" ]]; then
+    rmdir "$M_MANIFEST_DIR" 2>/dev/null && ok "Removed manifest directory" || true
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+echo
+echo -e "${GREEN}${BOLD}Uninstall complete.${NC}"


### PR DESCRIPTION
<html><head></head><body>
<h2>Changes from the original (2019) package</h2>
<h3>Bug fixes</h3>
<p>The original code had multiple outright bugs that prevented reliable operation:</p>

Bug | Original | Fixed
-- | -- | --
File handle leak | open(os.devnull, 'w') at module level, never closed | subprocess.DEVNULL
Wrong process API | .kill() + os.waitpid() mixing two incompatible interfaces | .terminate() → .wait(timeout=5) → .kill()
Wrong ALSA profile | PROFILE=a2dp | PROFILE=a2dp-source (Pi is the sender)
Relative config path | CONFIG_FILE = 'bt-devices' (broke if WorkingDirectory changed) | Absolute /etc/pyserver/bt-devices
D-Bus path bounds check | len(parts) >= 4 then accessed parts[4] — off-by-one | len(parts) >= 5
Python 2 relics | from __future__ import absolute_import, print_function, unicode_literals | Removed
No logging | dbg = False / bare print() — nothing went to journald | logging module writing to stdout, captured by systemd
No shutdown handler | Squeezelite processes left running when daemon stopped | SIGTERM/SIGINT handlers that cleanly stop all players
Deprecated systemd directive | StandardOutput=syslog | StandardOutput=journal
Missing service dependency | Monitor could start before bluealsa was ready | After=bluezalsa.service + Wants=bluezalsa.service
bluealsa binary not found | Build defaulted to /usr/local/bin, service pointed at /usr/bin | Added --prefix=/usr to build instructions
Wrong bluealsa flag | -p a2dp-source (old syntax, rejected by newer versions) | --profile=a2dp-source
Python deps with sudo pip | sudo pip3 install dbus-python | sudo apt-get install python3-dbus python3-gi
64-bit Pi OS path wrong | Only documented armhf ALSA plugin path | Both arm-linux-gnueabihf and aarch64-linux-gnu paths, auto-detected
No Bluetooth auto-power | Adapter powered off after boot, required manual bluetoothctl power on | AutoEnable=true in /etc/bluetooth/main.conf


<p>Detection checks (in order): WirePlumber process, system-level PipeWire service, PipeWire socket at <code>/run/user/1000/pipewire-0</code>. Override with <code>FORCE_AUDIO_BACKEND=pipewire|bluealsa sudo ./install.sh</code>.</p>
<hr>
<h3>Configuration</h3>
<p>The <code>bt-devices</code> config file was a flat <code>MAC=Name</code> text file. It is now an INI format with per-device options:</p>
<pre><code class="language-ini"># Old format
AA:BB:CC:DD:EE:FF=Livingroom

# New format
[AA:BB:CC:DD:EE:FF]
name = Livingroom
codec = aptx           # optional; bluealsa only
lms = 192.168.1.10     # optional; omit to auto-discover
</code></pre>
<ul>
<li><strong><code>codec</code></strong> — selects A2DP audio codec (aptX, AAC, SBC-XQ, etc.) on bluealsa</li>
<li><strong><code>lms</code></strong> — pins the LMS server address for installs where mDNS auto-discovery doesn't work (VLANs, etc.)</li>
<li><strong>Hot-reload</strong> — the file is re-read on every connection event; changes take effect without restarting the service</li>
<li><strong>Auto-migration</strong> — on first start after an update, the daemon detects the old flat format, converts to INI automatically, and saves the original as <code>bt-devices.bak</code></li>
<li><strong>Validation</strong> — malformed MAC addresses and missing <code>name</code> fields are logged and skipped rather than silently passed to squeezelite</li>
</ul>
<hr>
<h3>Security hardening</h3>
<p>Neither service had any sandboxing. Both now have systemd security directives:</p>
<p><strong><code>btspeaker-monitor.service</code></strong> (unprivileged <code>lms</code> user — tighter restrictions):</p>
<ul>
<li><code>NoNewPrivileges=yes</code></li>
<li><code>ProtectSystem=strict</code> — filesystem read-only except for carve-outs</li>
<li><code>ReadWritePaths=/etc/pyserver</code> — allows config migration write</li>
<li><code>ProtectHome=yes</code>, <code>PrivateTmp=yes</code></li>
<li><code>Wants=</code> instead of <code>Requires=</code> for bluezalsa — service starts on PipeWire systems where bluezalsa isn't installed</li>
</ul>
<p><strong><code>bluezalsa.service</code></strong> (runs as root, conservative):</p>
<ul>
<li><code>NoNewPrivileges=yes</code>, <code>ProtectHome=yes</code>, <code>PrivateTmp=yes</code></li>
<li><code>ProtectSystem</code> and <code>RestrictAddressFamilies</code> intentionally omitted — bluealsa needs direct kernel BT socket access</li>
</ul>
<hr>
<h3>Installer and tooling</h3>
<p>The original had no installer. Everything was manual steps in the README.</p>
<p><strong><code>install.sh</code></strong> — single-command installer:</p>
<ul>
<li>Auto-detects PipeWire vs bluealsa</li>
<li>Tries <code>apt install bluealsa</code> first, builds from source as fallback</li>
<li>Detects Pi architecture (armhf / aarch64) for correct ALSA plugin path</li>
<li>Creates <code>lms</code> system user and adds to audio group</li>
<li>Deploys all files, sets ownership and permissions</li>
<li>Configures Bluetooth auto-power-on</li>
<li>Enables and starts services</li>
<li>Writes an install manifest for the uninstaller</li>
<li>Idempotent — safe to re-run</li>
</ul>
<p><strong><code>install.sh --add-device</code></strong> — interactive pairing wizard:</p>
<ul>
<li>Scans for nearby BT devices</li>
<li>Runs <code>pair</code> / <code>trust</code> / <code>connect</code> via bluetoothctl</li>
<li>Prompts for player name and optional LMS server address</li>
<li>Writes the INI entry to <code>bt-devices</code> and restarts the monitor</li>
</ul>
<p><strong><code>install.sh --status</code></strong> — live system view (no sudo needed):</p>
<ul>
<li>Service running state with uptime</li>
<li>All configured devices from <code>bt-devices</code></li>
<li>Which BT devices are currently connected</li>
<li>Running squeezelite PIDs with full command lines</li>
<li>Install date, architecture, and audio backend from the manifest</li>
</ul>
<p><strong><code>install.sh --update</code></strong> — redeploys source files and restarts services without a full rebuild</p>
<p><strong><code>uninstall.sh</code></strong> — manifest-driven uninstaller:</p>
<ul>
<li>Reads <code>/var/lib/squeezelite-bluetooth/install.manifest</code> to remove exactly what was installed</li>
<li>Falls back to hardcoded defaults if manifest is missing</li>
<li>Stops/disables services, removes files, reverts <code>AutoEnable=true</code>, and optionally removes the <code>lms</code> user and bluealsa</li>
<li>Warns if <code>bt-devices</code> has configured speaker entries before removing it</li>
<li><code>--yes</code> flag for scripted/non-interactive removal</li>
</ul>
<hr>
<h3>Documentation</h3>
<ul>
